### PR TITLE
docs(gh-pages): bump CDN to cesium-heatbox@0.1.14

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -620,8 +620,8 @@
   </div>
   
   <!-- Heatbox library -->
-  <!-- Heatbox library (CDN pinned to 0.1.13 for hotfix validation) -->
-  <script src="https://unpkg.com/cesium-heatbox@0.1.13/dist/cesium-heatbox.umd.min.js?v=0.1.13"></script>
+  <!-- Heatbox library (CDN pinned to 0.1.14) -->
+  <script src="https://unpkg.com/cesium-heatbox@0.1.14/dist/cesium-heatbox.umd.min.js?v=0.1.14"></script>
   <!-- i18n dictionaries (externalized) -->
   <script src="i18n/en.js"></script>
   <script src="i18n/ja.js"></script>

--- a/playground/simple.html
+++ b/playground/simple.html
@@ -138,8 +138,8 @@
   </div>
   
 
-  <!-- Heatbox library (CDN pinned to 0.1.13 for hotfix validation) -->
-  <script src="https://unpkg.com/cesium-heatbox@0.1.13/dist/cesium-heatbox.umd.min.js?v=0.1.13"></script>
+  <!-- Heatbox library (CDN pinned to 0.1.14) -->
+  <script src="https://unpkg.com/cesium-heatbox@0.1.14/dist/cesium-heatbox.umd.min.js?v=0.1.14"></script>
   <script src="simple-app.js"></script>
   <script>
     // Mobile nav dropdown


### PR DESCRIPTION
Release 0.1.14 is out; update website to load cesium-heatbox@0.1.14.\n\n- Pin CDN to v0.1.14 in Playground + Quick Start\n- Resolver support remains warn-only per 0.1.13/0.1.14; AdaptiveController opacity/width ranges to follow per ROADMAP\n