### PR TITLE
feat: add version comparison demos and release notes for v1.3.5

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,23 @@
 # Cesium Heatbox リリースノート
 
+## バージョン 1.3.5（2026-04-07）
+
+**Version comparison demos / measured temporal follow-up**
+
+### ハイライト
+- **Measured version comparisons**: CDN 固定版の `1.2.1` / `1.3.4` を同条件で比較する observability / temporal デモを追加し、単一時点と時系列の両方で差分を確認できるようにしました。
+- **Temporal benchmark correction**: temporal 比較ページは `viewer.clock.currentTime` の反映完了を `totalEntities` 一致で待つようにし、`updateInterval=0` で時刻ジャンプ性能をより公平に比較できるようにしました。
+
+### 主な変更
+- `examples/observability/version-compare-demo.html` は `setData()` 完了まで待機するよう修正し、元ポイント表示切替と固定 seed データで `1.2.1` / `1.3.4` の描画比較を行えるようにしました。
+- `examples/temporal/version-compare-demo.html` は CZML + temporal slices を使い、`viewer.clock.currentTime` の時刻ジャンプごとの反映時間を `totalEntities` 一致ベースで比較できるようにしました。
+- `examples/observability/README.md` と `examples/temporal/README.md` に比較デモの入口を追加しました。
+
+### 計測メモ
+- 単一時点の local CDN 比較では、`desktop-balanced` / `voxelSize=80` 条件で定常更新時間が `1.2.1` 比で概ね `10-13%` 改善、`5000-10000 points` の初回 `setData` は概ね `17-19%` 改善でした。
+- temporal 比較では、`commute` シナリオ・`hours=0,12`・`updateInterval=0` の確認用ランで、平均時刻ジャンプ時間が `1566.20ms -> 569.55ms` と改善し、`1.3.4` 側で時間移動時の反映が速くなることを確認しました。
+- 上記は examples 上の実測値であり、環境・カメラ位置・voxelSize・scenario 構成によって変動します。
+
 ## バージョン 1.3.4（2026-04-07）
 
 **Temporal example recovery / camera refresh fix**

--- a/examples/observability/README.md
+++ b/examples/observability/README.md
@@ -8,6 +8,7 @@
 | --- | --- |
 | `performance-overlay-demo.html` | パフォーマンスオーバーレイの表示とベンチマーク実行。プロファイル別の比較が可能。 |
 | `adaptive-phase3-demo.html` | ADR-0011 Phase 3 の適応制御デモ。密度検出・重なり検知・拡張オーバーレイを搭載。 |
+| `version-compare-demo.html` | CDN 上の `1.2.1` と `1.3.4` を同一データで比較する A/B ベンチ。 |
 
 ## Cesium Setup / Cesium 初期化
 
@@ -18,7 +19,7 @@
 ## How to Run / 実行方法
 
 1. `npm install` 済みのリポジトリで `npx http-server examples/observability` を実行するか、任意の静的サーバーで公開します。
-2. ブラウザで `performance-overlay-demo.html` または `adaptive-phase3-demo.html` にアクセスします。
+2. ブラウザで `performance-overlay-demo.html`、`adaptive-phase3-demo.html`、または `version-compare-demo.html` にアクセスします。
 3. UI からプロファイル変更、ボクセル数調整、オーバーレイの表示切替などを行い、ログはブラウザコンソールで確認できます。
 
 ## Notes / 補足

--- a/examples/observability/version-compare-demo.html
+++ b/examples/observability/version-compare-demo.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta http-equiv="refresh" content="0; url=./version-compare/index.html">
+    <title>Redirecting...</title>
+</head>
+<body>
+    <p><a href="./version-compare/index.html">Go to version compare demo</a></p>
+</body>
+</html>

--- a/examples/observability/version-compare/index.html
+++ b/examples/observability/version-compare/index.html
@@ -1,0 +1,502 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="utf-8">
+    <title>CesiumJS Heatbox - Version Performance Compare</title>
+    <script src="https://cesium.com/downloads/cesiumjs/releases/1.120/Build/Cesium/Cesium.js"></script>
+    <link href="https://cesium.com/downloads/cesiumjs/releases/1.120/Build/Cesium/Widgets/widgets.css" rel="stylesheet">
+    <link href="../../common/demo.css" rel="stylesheet">
+    <script>
+        window.CESIUM_BASE_URL = 'https://cesium.com/downloads/cesiumjs/releases/1.120/Build/Cesium/';
+        if (typeof Cesium !== 'undefined' && Cesium.Ion) {
+            Cesium.Ion.defaultAccessToken = null;
+        }
+    </script>
+    <script src="../../common/camera.js"></script>
+    <style>
+        .hb-grid {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 10px;
+        }
+
+        .hb-inline {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+
+        .hb-inline input {
+            flex: 1;
+        }
+
+        .hb-results {
+            margin-top: 14px;
+            font-size: 12px;
+            border-radius: 12px;
+            overflow: hidden;
+            border: 1px solid rgba(148, 163, 184, 0.18);
+        }
+
+        .hb-results table {
+            width: 100%;
+            border-collapse: collapse;
+            background: rgba(15, 23, 42, 0.6);
+        }
+
+        .hb-results th,
+        .hb-results td {
+            padding: 8px 10px;
+            border-bottom: 1px solid rgba(148, 163, 184, 0.12);
+            text-align: left;
+            vertical-align: top;
+        }
+
+        .hb-results th {
+            color: #7dd3fc;
+            font-weight: 600;
+            background: rgba(15, 23, 42, 0.85);
+        }
+
+        .hb-results td {
+            color: #e2e8f0;
+        }
+
+        .hb-results tr:last-child td {
+            border-bottom: none;
+        }
+
+        .hb-winner {
+            color: #86efac;
+            font-weight: 700;
+        }
+
+        .hb-metric {
+            color: #94a3b8;
+        }
+    </style>
+</head>
+<body>
+    <div id="cesiumContainer"></div>
+
+    <aside class="hb-panel" id="controlsPanel">
+        <h2>Version Compare</h2>
+        <p>`1.2.1` と `1.3.4` を同一ビューア・同一データで比較します。初回処理と繰り返し更新の差を見ます。</p>
+
+        <div class="hb-group">
+            <label for="profileSelect">Profile</label>
+            <select id="profileSelect">
+                <option value="none">No Profile</option>
+                <option value="mobile-fast">mobile-fast</option>
+                <option value="desktop-balanced" selected>desktop-balanced</option>
+                <option value="dense-data">dense-data</option>
+                <option value="sparse-data">sparse-data</option>
+            </select>
+        </div>
+
+        <div class="hb-grid">
+            <div class="hb-group">
+                <label for="pointCount">Points</label>
+                <input id="pointCount" type="number" min="100" max="10000" step="100" value="2000">
+            </div>
+            <div class="hb-group">
+                <label for="iterations">Iterations</label>
+                <input id="iterations" type="number" min="3" max="50" step="1" value="8">
+            </div>
+        </div>
+
+        <div class="hb-grid">
+            <div class="hb-group">
+                <label for="seedInput">Seed</label>
+                <input id="seedInput" type="number" min="1" step="1" value="20260407">
+            </div>
+            <div class="hb-group">
+                <label for="voxelSizeInput">Voxel Size</label>
+                <input id="voxelSizeInput" type="number" min="10" max="500" step="10" value="80">
+            </div>
+        </div>
+
+        <div class="hb-group">
+            <label class="hb-checkbox-label">
+                <input id="fitViewCheckbox" type="checkbox">
+                fitView を各計測後に実行
+            </label>
+        </div>
+
+        <div class="hb-group">
+            <label class="hb-checkbox-label">
+                <input id="showPointsCheckbox" type="checkbox" checked>
+                元ポイントを表示
+            </label>
+        </div>
+
+        <div class="hb-buttons">
+            <button class="hb-btn hb-btn-secondary" id="prepareBtn">データ生成</button>
+            <button class="hb-btn hb-btn-primary" id="compareBtn">比較実行</button>
+        </div>
+
+        <div class="hb-info-box">
+            <div><strong>CDN Targets</strong></div>
+            <div>`1.2.1`: unpkg 固定 URL</div>
+            <div>`1.3.4`: unpkg 固定 URL</div>
+            <div>同じ Entity 配列を両版へ順番に渡します。</div>
+            <div>このページは temporal / CZML 比較ではなく、単一時点データの比較です。</div>
+        </div>
+
+        <div id="status" class="hb-status">準備待ち。</div>
+        <div id="results" class="hb-results"></div>
+    </aside>
+
+    <script type="module">
+        const CameraHelper = window.HeatboxDemoCamera || null;
+        const SHINJUKU_CENTER = { lon: 139.6917, lat: 35.6895 };
+        const INITIAL_BOUNDS = {
+            minLon: SHINJUKU_CENTER.lon - 0.015,
+            maxLon: SHINJUKU_CENTER.lon + 0.015,
+            minLat: SHINJUKU_CENTER.lat - 0.015,
+            maxLat: SHINJUKU_CENTER.lat + 0.015,
+            minAlt: 0,
+            maxAlt: 300
+        };
+        const VERSION_URLS = {
+            '1.2.1': 'https://unpkg.com/cesium-heatbox@1.2.1/dist/cesium-heatbox.umd.min.js',
+            '1.3.4': 'https://unpkg.com/cesium-heatbox@1.3.4/dist/cesium-heatbox.umd.min.js'
+        };
+        const heatboxCache = new Map();
+
+        const pointCountInput = document.getElementById('pointCount');
+        const iterationsInput = document.getElementById('iterations');
+        const seedInput = document.getElementById('seedInput');
+        const voxelSizeInput = document.getElementById('voxelSizeInput');
+        const profileSelect = document.getElementById('profileSelect');
+        const fitViewCheckbox = document.getElementById('fitViewCheckbox');
+        const showPointsCheckbox = document.getElementById('showPointsCheckbox');
+        const prepareBtn = document.getElementById('prepareBtn');
+        const compareBtn = document.getElementById('compareBtn');
+        const statusEl = document.getElementById('status');
+        const resultsEl = document.getElementById('results');
+
+        function createImageryProvider() {
+            return new Cesium.UrlTemplateImageryProvider({
+                url: 'https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png',
+                subdomains: 'abcd',
+                maximumLevel: 19,
+                credit: '© OpenStreetMap contributors © CARTO'
+            });
+        }
+
+        function createTerrainProvider() {
+            try {
+                if (Cesium.Ion && Cesium.Ion.defaultAccessToken && Cesium.Ion.defaultAccessToken !== 'null') {
+                    return Cesium.createWorldTerrain();
+                }
+            } catch (error) {
+                console.warn('World Terrain unavailable, falling back to EllipsoidTerrainProvider:', error);
+            }
+            return new Cesium.EllipsoidTerrainProvider();
+        }
+
+        const imageryProvider = createImageryProvider();
+        const viewer = new Cesium.Viewer('cesiumContainer', {
+            imageryProvider,
+            terrainProvider: createTerrainProvider(),
+            baseLayerPicker: false,
+            timeline: false,
+            animation: false,
+            geocoder: false,
+            navigationHelpButton: false
+        });
+
+        viewer.imageryLayers.removeAll();
+        viewer.imageryLayers.addImageryProvider(imageryProvider);
+        viewer.scene.globe.baseColor = Cesium.Color.fromCssColorString('#0f172a');
+
+        if (CameraHelper?.focus) {
+            CameraHelper.focus(viewer, { bounds: INITIAL_BOUNDS, useDefaultBounds: false });
+        } else {
+            viewer.camera.setView({
+                destination: Cesium.Cartesian3.fromDegrees(SHINJUKU_CENTER.lon, SHINJUKU_CENTER.lat, 14000),
+                orientation: {
+                    heading: 0,
+                    pitch: -Cesium.Math.PI_OVER_FOUR,
+                    roll: 0
+                }
+            });
+        }
+
+        let currentData = [];
+
+        function setStatus(message, isError = false) {
+            statusEl.textContent = message;
+            statusEl.classList.toggle('error', isError);
+        }
+
+        function createSeededRandom(seed) {
+            let state = seed % 2147483647;
+            if (state <= 0) state += 2147483646;
+            return () => {
+                state = state * 16807 % 2147483647;
+                return (state - 1) / 2147483646;
+            };
+        }
+
+        function clearCurrentEntities() {
+            if (currentData.length === 0) return;
+            currentData.forEach((entity) => viewer.entities.remove(entity));
+            currentData = [];
+        }
+
+        function updatePointVisibility() {
+            const showPoints = showPointsCheckbox.checked;
+            currentData.forEach((entity) => {
+                if (entity.point) {
+                    entity.point.show = showPoints;
+                }
+            });
+        }
+
+        function generateTestData(count, seed) {
+            clearCurrentEntities();
+            const random = createSeededRandom(seed);
+            const entities = [];
+
+            while (entities.length < count) {
+                const centerLon = INITIAL_BOUNDS.minLon + random() * (INITIAL_BOUNDS.maxLon - INITIAL_BOUNDS.minLon);
+                const centerLat = INITIAL_BOUNDS.minLat + random() * (INITIAL_BOUNDS.maxLat - INITIAL_BOUNDS.minLat);
+                const clusterSize = random() < 0.35 ? Math.min(6, count - entities.length) : 1;
+
+                for (let i = 0; i < clusterSize; i++) {
+                    const lon = Cesium.Math.clamp(centerLon + (random() - 0.5) * 0.004, INITIAL_BOUNDS.minLon, INITIAL_BOUNDS.maxLon);
+                    const lat = Cesium.Math.clamp(centerLat + (random() - 0.5) * 0.004, INITIAL_BOUNDS.minLat, INITIAL_BOUNDS.maxLat);
+                    const alt = INITIAL_BOUNDS.minAlt + random() * (INITIAL_BOUNDS.maxAlt - INITIAL_BOUNDS.minAlt);
+                    const value = 30 + (random() * 90);
+
+                    entities.push(viewer.entities.add({
+                        position: Cesium.Cartesian3.fromDegrees(lon, lat, alt),
+                        point: {
+                            pixelSize: 4,
+                            color: Cesium.Color.fromCssColorString('#fbbf24').withAlpha(0.75),
+                            outlineColor: Cesium.Color.fromCssColorString('#0f172a').withAlpha(0.8),
+                            outlineWidth: 1,
+                            show: true
+                        },
+                        properties: { value }
+                    }));
+
+                    if (entities.length >= count) break;
+                }
+            }
+
+            currentData = entities;
+            return currentData;
+        }
+
+        function getHeapMB() {
+            if (performance && performance.memory && typeof performance.memory.usedJSHeapSize === 'number') {
+                return performance.memory.usedJSHeapSize / 1024 / 1024;
+            }
+            return null;
+        }
+
+        function calcStats(values) {
+            const total = values.reduce((sum, value) => sum + value, 0);
+            return {
+                avg: total / values.length,
+                min: Math.min(...values),
+                max: Math.max(...values)
+            };
+        }
+
+        function formatMs(value) {
+            return `${value.toFixed(2)} ms`;
+        }
+
+        function formatMaybeMB(value) {
+            return value == null ? 'n/a' : `${value.toFixed(2)} MB`;
+        }
+
+        function escapeHtml(value) {
+            return String(value)
+                .replaceAll('&', '&amp;')
+                .replaceAll('<', '&lt;')
+                .replaceAll('>', '&gt;')
+                .replaceAll('"', '&quot;')
+                .replaceAll('\'', '&#39;');
+        }
+
+        async function loadHeatbox(version) {
+            if (heatboxCache.has(version)) {
+                return heatboxCache.get(version);
+            }
+
+            const url = VERSION_URLS[version];
+            if (!url) {
+                throw new Error(`Unknown version: ${version}`);
+            }
+
+            const HeatboxClass = await new Promise((resolve, reject) => {
+                const script = document.createElement('script');
+                script.src = url;
+                script.async = true;
+                script.onload = () => {
+                    const loaded = window.CesiumHeatbox || window.Heatbox;
+                    if (!loaded) {
+                        reject(new Error(`Heatbox global not found after loading ${url}`));
+                        return;
+                    }
+                    resolve(loaded);
+                };
+                script.onerror = () => reject(new Error(`Failed to load ${url}`));
+                document.head.appendChild(script);
+            });
+
+            heatboxCache.set(version, HeatboxClass);
+            return HeatboxClass;
+        }
+
+        async function benchmarkVersion(version, options) {
+            const HeatboxClass = await loadHeatbox(version);
+            const heapBefore = getHeapMB();
+            const initStart = performance.now();
+            const heatbox = new HeatboxClass(viewer, options);
+            const initMs = performance.now() - initStart;
+
+            const firstSetStart = performance.now();
+            await heatbox.setData(currentData, { _skipAutoView: true });
+            const firstSetMs = performance.now() - firstSetStart;
+
+            if (fitViewCheckbox.checked && typeof heatbox.fitView === 'function') {
+                await heatbox.fitView(null, {
+                    paddingPercent: 0.1,
+                    headingDegrees: 0,
+                    pitchDegrees: -40
+                });
+            }
+
+            const runs = [];
+            const iterations = Number.parseInt(iterationsInput.value, 10);
+            for (let i = 0; i < iterations; i++) {
+                const start = performance.now();
+                await heatbox.setData(currentData, { _skipAutoView: true });
+                runs.push(performance.now() - start);
+            }
+
+            const stats = calcStats(runs);
+            const heatboxStats = typeof heatbox.getStatistics === 'function' ? (heatbox.getStatistics() || {}) : {};
+            heatbox.destroy();
+            await new Promise((resolve) => requestAnimationFrame(() => resolve()));
+            const heapAfter = getHeapMB();
+
+            return {
+                version,
+                initMs,
+                firstSetMs,
+                avgUpdateMs: stats.avg,
+                minUpdateMs: stats.min,
+                maxUpdateMs: stats.max,
+                heapDeltaMB: (heapBefore != null && heapAfter != null) ? (heapAfter - heapBefore) : null,
+                renderedVoxels: heatboxStats.renderedVoxels ?? 'n/a',
+                totalVoxels: heatboxStats.totalVoxels ?? 'n/a'
+            };
+        }
+
+        function fasterVersion(a, b, key) {
+            if (!(key in a) || !(key in b)) return '';
+            if (typeof a[key] !== 'number' || typeof b[key] !== 'number') return '';
+            if (Math.abs(a[key] - b[key]) < 0.01) return 'ほぼ同等';
+            return a[key] < b[key] ? a.version : b.version;
+        }
+
+        function renderResults(results) {
+            const [v121, v134] = results;
+            const rows = [
+                ['初期化', formatMs(v121.initMs), formatMs(v134.initMs), fasterVersion(v121, v134, 'initMs')],
+                ['初回 setData', formatMs(v121.firstSetMs), formatMs(v134.firstSetMs), fasterVersion(v121, v134, 'firstSetMs')],
+                ['平均更新', formatMs(v121.avgUpdateMs), formatMs(v134.avgUpdateMs), fasterVersion(v121, v134, 'avgUpdateMs')],
+                ['最小更新', formatMs(v121.minUpdateMs), formatMs(v134.minUpdateMs), fasterVersion(v121, v134, 'minUpdateMs')],
+                ['最大更新', formatMs(v121.maxUpdateMs), formatMs(v134.maxUpdateMs), fasterVersion(v121, v134, 'maxUpdateMs')],
+                ['Heap 差分', formatMaybeMB(v121.heapDeltaMB), formatMaybeMB(v134.heapDeltaMB), '参考値'],
+                ['Rendered Voxels', escapeHtml(v121.renderedVoxels), escapeHtml(v134.renderedVoxels), ''],
+                ['Total Voxels', escapeHtml(v121.totalVoxels), escapeHtml(v134.totalVoxels), '']
+            ];
+
+            const body = rows.map(([metric, left, right, winner]) => `
+                <tr>
+                    <td class="hb-metric">${metric}</td>
+                    <td>${left}</td>
+                    <td>${right}</td>
+                    <td class="hb-winner">${escapeHtml(winner)}</td>
+                </tr>
+            `).join('');
+
+            resultsEl.innerHTML = `
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Metric</th>
+                            <th>1.2.1</th>
+                            <th>1.3.4</th>
+                            <th>Winner</th>
+                        </tr>
+                    </thead>
+                    <tbody>${body}</tbody>
+                </table>
+            `;
+        }
+
+        function buildHeatboxOptions() {
+            const profile = profileSelect.value === 'none' ? undefined : profileSelect.value;
+            return {
+                profile,
+                voxelSize: Number.parseInt(voxelSizeInput.value, 10),
+                performanceOverlay: {
+                    enabled: false
+                }
+            };
+        }
+
+        prepareBtn.addEventListener('click', () => {
+            const count = Number.parseInt(pointCountInput.value, 10);
+            const seed = Number.parseInt(seedInput.value, 10);
+            generateTestData(count, seed);
+            updatePointVisibility();
+            setStatus(`データ生成完了: ${count} points / seed=${seed}`);
+        });
+
+        showPointsCheckbox.addEventListener('change', () => {
+            updatePointVisibility();
+        });
+
+        compareBtn.addEventListener('click', async () => {
+            try {
+                compareBtn.disabled = true;
+                resultsEl.innerHTML = '';
+
+                if (currentData.length === 0) {
+                    prepareBtn.click();
+                }
+
+                setStatus('CDN 版をロードして比較中...');
+                const options = buildHeatboxOptions();
+                const first = await benchmarkVersion('1.2.1', options);
+                setStatus('1.2.1 計測完了。1.3.4 を計測中...');
+                const second = await benchmarkVersion('1.3.4', options);
+                renderResults([first, second]);
+
+                setStatus(
+                    `比較完了\n1.2.1 avg=${first.avgUpdateMs.toFixed(2)} ms\n1.3.4 avg=${second.avgUpdateMs.toFixed(2)} ms`
+                );
+            } catch (error) {
+                console.error(error);
+                setStatus(`比較失敗: ${error.message}`, true);
+            } finally {
+                compareBtn.disabled = false;
+            }
+        });
+
+        window.addEventListener('load', () => {
+            prepareBtn.click();
+        });
+    </script>
+</body>
+</html>

--- a/examples/temporal/README.md
+++ b/examples/temporal/README.md
@@ -1,6 +1,6 @@
 # Temporal Samples / 時系列サンプル
 
-このディレクトリは v1.3.4 時点の `temporal` オプションを使った動作例をまとめています。各 HTML は UMD ビルド（`dist/cesium-heatbox.umd.min.js`）を直接読み込み、`viewer.clock` と Heatbox の自動同期を確認できます。
+このディレクトリは v1.3.x 系の `temporal` オプションを使った動作例をまとめています。各 HTML は UMD ビルド（`dist/cesium-heatbox.umd.min.js`）を直接読み込み、`viewer.clock` と Heatbox の自動同期を確認できます。
 
 ## サンプル一覧
 
@@ -11,6 +11,7 @@
 | `global-vs-per-time.html` | ラジオで Global/Per-Time を切り替え、統計の差を比較。 |
 | `simulation.html` | 平日/イベント/週末のシナリオを動的切り替えし、`updateInterval` や `outOfRangeBehavior` を調整。 |
 | `advanced-temporal.html` | `interpolate` / `dataSource` / `useWorker` を同時に試す v1.3.4 向け拡張デモ。 |
+| `version-compare-demo.html` | `1.2.1` と `1.3.4` を temporal/CZML 付きで比較し、時刻ジャンプの反映時間を計測。 |
 
 ## 使い方
 

--- a/examples/temporal/version-compare-demo.html
+++ b/examples/temporal/version-compare-demo.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="refresh" content="0; url=./version-compare/index.html">
+  <title>Redirecting...</title>
+</head>
+<body>
+  <p><a href="./version-compare/index.html">Go to temporal version compare demo</a></p>
+</body>
+</html>

--- a/examples/temporal/version-compare/index.html
+++ b/examples/temporal/version-compare/index.html
@@ -1,0 +1,459 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <title>Temporal Version Compare</title>
+  <script src="https://cesium.com/downloads/cesiumjs/releases/1.120/Build/Cesium/Cesium.js"></script>
+  <link rel="stylesheet" href="https://cesium.com/downloads/cesiumjs/releases/1.120/Build/Cesium/Widgets/widgets.css">
+  <link rel="stylesheet" href="../../common/demo.css">
+  <script>
+    window.CESIUM_BASE_URL = 'https://cesium.com/downloads/cesiumjs/releases/1.120/Build/Cesium/';
+    if (typeof Cesium !== 'undefined' && Cesium.Ion) {
+      Cesium.Ion.defaultAccessToken = null;
+    }
+  </script>
+  <script src="../../common/camera.js"></script>
+  <script src="../temporal-data.js"></script>
+  <style>
+    .hb-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 10px;
+    }
+
+    .hb-results {
+      margin-top: 14px;
+      font-size: 12px;
+      border-radius: 12px;
+      overflow: hidden;
+      border: 1px solid rgba(148, 163, 184, 0.18);
+      background: rgba(15, 23, 42, 0.6);
+    }
+
+    .hb-results table {
+      width: 100%;
+      border-collapse: collapse;
+    }
+
+    .hb-results th,
+    .hb-results td {
+      padding: 8px 10px;
+      border-bottom: 1px solid rgba(148, 163, 184, 0.12);
+      text-align: left;
+      vertical-align: top;
+    }
+
+    .hb-results tr:last-child td {
+      border-bottom: none;
+    }
+
+    .hb-muted {
+      color: #94a3b8;
+    }
+  </style>
+</head>
+<body>
+  <div id="cesiumContainer"></div>
+
+  <aside class="hb-panel">
+    <h2>Temporal Compare</h2>
+    <p>CZML と temporal slices を使って、時間移動時の反映時間を `1.2.1` と `1.3.4` で比較します。</p>
+
+    <div class="hb-grid">
+      <div class="hb-group">
+        <label for="scenarioSelect">Scenario</label>
+        <select id="scenarioSelect">
+          <option value="commute" selected>commute</option>
+          <option value="event">event</option>
+          <option value="weekend">weekend</option>
+        </select>
+      </div>
+      <div class="hb-group">
+        <label for="voxelSizeInput">Voxel Size</label>
+        <input id="voxelSizeInput" type="number" min="10" max="200" step="5" value="45">
+      </div>
+    </div>
+
+    <div class="hb-grid">
+      <div class="hb-group">
+        <label for="hoursInput">Hours</label>
+        <input id="hoursInput" type="text" value="0,6,8,12,18,21">
+      </div>
+      <div class="hb-group">
+        <label for="updateIntervalInput">Update Interval</label>
+        <input id="updateIntervalInput" type="number" min="0" max="1000" step="25" value="0">
+      </div>
+    </div>
+
+    <div class="hb-group">
+      <label class="hb-checkbox-label">
+        <input id="showCzmlCheckbox" type="checkbox" checked>
+        CZML ポイントを表示
+      </label>
+    </div>
+
+    <div class="hb-buttons">
+      <button class="hb-btn hb-btn-secondary" id="prepareBtn">シナリオ準備</button>
+      <button class="hb-btn hb-btn-primary" id="compareBtn">Temporal 比較</button>
+    </div>
+
+    <div class="hb-info-box">
+      <div><strong>What It Measures</strong></div>
+      <div>初期 temporal 初期化、各時刻ジャンプ時の反映時間、描画 voxel 数を比較します。</div>
+      <div>単一時点の `setData` 比較ではなく、実際に `viewer.clock.currentTime` を動かします。</div>
+      <div>`updateInterval=0` は毎フレーム更新として扱います。</div>
+    </div>
+
+    <div id="status" class="hb-status">準備待ち。</div>
+    <div id="results" class="hb-results"></div>
+  </aside>
+
+  <script type="module">
+    const VERSION_URLS = {
+      '1.2.1': 'https://unpkg.com/cesium-heatbox@1.2.1/dist/cesium-heatbox.umd.min.js',
+      '1.3.4': 'https://unpkg.com/cesium-heatbox@1.3.4/dist/cesium-heatbox.umd.min.js'
+    };
+    const heatboxCache = new Map();
+    const CameraHelper = window.HeatboxDemoCamera || null;
+
+    const scenarioSelect = document.getElementById('scenarioSelect');
+    const voxelSizeInput = document.getElementById('voxelSizeInput');
+    const hoursInput = document.getElementById('hoursInput');
+    const updateIntervalInput = document.getElementById('updateIntervalInput');
+    const showCzmlCheckbox = document.getElementById('showCzmlCheckbox');
+    const prepareBtn = document.getElementById('prepareBtn');
+    const compareBtn = document.getElementById('compareBtn');
+    const statusEl = document.getElementById('status');
+    const resultsEl = document.getElementById('results');
+
+    const viewer = initializeViewer();
+    let currentScenario = null;
+
+    function setStatus(message, isError = false) {
+      statusEl.textContent = message;
+      statusEl.classList.toggle('error', isError);
+    }
+
+    function escapeHtml(value) {
+      return String(value)
+        .replaceAll('&', '&amp;')
+        .replaceAll('<', '&lt;')
+        .replaceAll('>', '&gt;')
+        .replaceAll('"', '&quot;')
+        .replaceAll('\'', '&#39;');
+    }
+
+    function createImageryProvider() {
+      return new Cesium.UrlTemplateImageryProvider({
+        url: 'https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png',
+        subdomains: 'abcd',
+        maximumLevel: 19,
+        credit: '© OpenStreetMap contributors © CARTO'
+      });
+    }
+
+    function createTerrainProvider() {
+      try {
+        if (Cesium.Ion && Cesium.Ion.defaultAccessToken && Cesium.Ion.defaultAccessToken !== 'null') {
+          return Cesium.createWorldTerrain();
+        }
+      } catch (error) {
+        console.warn('World Terrain unavailable, falling back to EllipsoidTerrainProvider.', error);
+      }
+      return new Cesium.EllipsoidTerrainProvider();
+    }
+
+    function initializeViewer() {
+      const imageryProvider = createImageryProvider();
+      const viewerInstance = new Cesium.Viewer('cesiumContainer', {
+        baseLayerPicker: false,
+        animation: true,
+        timeline: true,
+        sceneModePicker: false,
+        geocoder: false,
+        homeButton: false,
+        navigationHelpButton: false,
+        imageryProvider,
+        terrainProvider: createTerrainProvider()
+      });
+      viewerInstance.imageryLayers.removeAll();
+      viewerInstance.imageryLayers.addImageryProvider(imageryProvider);
+      viewerInstance.scene.globe.baseColor = Cesium.Color.fromCssColorString('#0f172a');
+      viewerInstance.scene.backgroundColor = Cesium.Color.fromCssColorString('#020617');
+      return viewerInstance;
+    }
+
+    function focusCamera() {
+      const bounds = CameraHelper?.DEFAULT_BOUNDS || {
+        minLon: 139.688,
+        maxLon: 139.712,
+        minLat: 35.676,
+        maxLat: 35.702,
+        minAlt: 0,
+        maxAlt: 300
+      };
+      const focusConfig = {
+        bounds,
+        useDefaultBounds: true,
+        pitchDegrees: -48,
+        altitude: 3400
+      };
+      if (CameraHelper?.focus) {
+        CameraHelper.focus(viewer, focusConfig);
+        return;
+      }
+      const centerLon = (bounds.minLon + bounds.maxLon) / 2;
+      const centerLat = (bounds.minLat + bounds.maxLat) / 2;
+      viewer.camera.setView({
+        destination: Cesium.Cartesian3.fromDegrees(centerLon, centerLat - 0.018, 3400),
+        orientation: {
+          heading: Cesium.Math.toRadians(-6),
+          pitch: Cesium.Math.toRadians(-47),
+          roll: 0
+        }
+      });
+    }
+
+    function setCzmlVisibility(visible) {
+      if (!viewer.dataSources) return;
+      const list = viewer.dataSources._dataSources || [];
+      list.forEach((ds) => {
+        ds.show = visible;
+      });
+    }
+
+    async function prepareScenario() {
+      currentScenario = await TemporalHeatboxDemo.loadScenario(viewer, scenarioSelect.value);
+      const start = Cesium.JulianDate.fromIso8601(currentScenario.start);
+      const stop = Cesium.JulianDate.fromIso8601(currentScenario.stop);
+      viewer.clock.startTime = Cesium.JulianDate.clone(start);
+      viewer.clock.stopTime = Cesium.JulianDate.clone(stop);
+      viewer.clock.currentTime = Cesium.JulianDate.clone(start);
+      viewer.clock.clockRange = Cesium.ClockRange.CLAMPED;
+      viewer.clock.multiplier = 600;
+      viewer.clock.shouldAnimate = false;
+      viewer.timeline.zoomTo(start, stop);
+      setCzmlVisibility(showCzmlCheckbox.checked);
+      focusCamera();
+      setStatus(`シナリオ準備完了: ${currentScenario.label}`);
+      return currentScenario;
+    }
+
+    async function loadHeatbox(version) {
+      if (heatboxCache.has(version)) {
+        return heatboxCache.get(version);
+      }
+
+      const url = VERSION_URLS[version];
+      const HeatboxClass = await new Promise((resolve, reject) => {
+        const script = document.createElement('script');
+        script.src = url;
+        script.async = true;
+        script.onload = () => {
+          const loaded = window.CesiumHeatbox || window.Heatbox;
+          if (!loaded) {
+            reject(new Error(`Heatbox global not found after loading ${url}`));
+            return;
+          }
+          resolve(loaded);
+        };
+        script.onerror = () => reject(new Error(`Failed to load ${url}`));
+        document.head.appendChild(script);
+      });
+
+      heatboxCache.set(version, HeatboxClass);
+      return HeatboxClass;
+    }
+
+    function parseHours() {
+      return hoursInput.value
+        .split(',')
+        .map((value) => Number.parseInt(value.trim(), 10))
+        .filter((value) => Number.isFinite(value) && value >= 0 && value <= 23);
+    }
+
+    function getUpdateInterval() {
+      const value = Number.parseInt(updateIntervalInput.value, 10);
+      return Number.isFinite(value) ? value : 0;
+    }
+
+    async function nextFrame() {
+      await new Promise((resolve) => requestAnimationFrame(() => resolve()));
+      await new Promise((resolve) => requestAnimationFrame(() => resolve()));
+    }
+
+    async function waitForTemporalStats(heatbox, timeoutMs = 3000, expectedEntities = null) {
+      const start = performance.now();
+      let stableCount = 0;
+      let lastSignature = '';
+      while ((performance.now() - start) < timeoutMs) {
+        const stats = typeof heatbox.getStatistics === 'function' ? heatbox.getStatistics() : null;
+        if (stats && Number.isFinite(stats.totalVoxels) && Number.isFinite(stats.renderedVoxels)) {
+          const entityMatch = expectedEntities == null || stats.totalEntities === expectedEntities;
+          const signature = `${stats.totalEntities}:${stats.totalVoxels}:${stats.renderedVoxels}`;
+          if (entityMatch) {
+            stableCount = signature === lastSignature ? stableCount + 1 : 1;
+            lastSignature = signature;
+            if (stableCount >= 2) {
+              return stats;
+            }
+          }
+        }
+        await nextFrame();
+      }
+      return heatbox.getStatistics ? (heatbox.getStatistics() || {}) : {};
+    }
+
+    async function measureTemporalVersion(version, scenario, hours) {
+      const HeatboxClass = await loadHeatbox(version);
+      const options = {
+        voxelSize: Number.parseInt(voxelSizeInput.value, 10),
+        autoView: false,
+        temporal: {
+          enabled: true,
+          data: scenario.slices,
+          classificationScope: scenario.defaultScope || 'global',
+          updateInterval: getUpdateInterval(),
+          outOfRangeBehavior: 'clear'
+        }
+      };
+
+      viewer.clock.currentTime = Cesium.JulianDate.fromIso8601(scenario.start);
+      viewer.clock.shouldAnimate = false;
+      await nextFrame();
+
+      const initStart = performance.now();
+      const heatbox = new HeatboxClass(viewer, options);
+      await waitForTemporalStats(heatbox, 5000, scenario.slices[0]?.data?.length ?? null);
+      const initMs = performance.now() - initStart;
+
+      const transitions = [];
+      for (const hour of hours) {
+        const slice = scenario.slices[hour];
+        const target = Cesium.JulianDate.addHours(
+          Cesium.JulianDate.fromIso8601(scenario.start),
+          hour,
+          new Cesium.JulianDate()
+        );
+        const moveStart = performance.now();
+        viewer.clock.currentTime = target;
+        if (heatbox._timeController && typeof heatbox._timeController._onTick === 'function') {
+          heatbox._timeController._onTick(viewer.clock);
+        }
+        await nextFrame();
+        await new Promise((resolve) => setTimeout(resolve, getUpdateInterval() + 20));
+        const stats = await waitForTemporalStats(heatbox, 4000, slice?.data?.length ?? null);
+        transitions.push({
+          hour,
+          ms: performance.now() - moveStart,
+          totalEntities: stats.totalEntities ?? 'n/a',
+          renderedVoxels: stats.renderedVoxels ?? 'n/a',
+          totalVoxels: stats.totalVoxels ?? 'n/a'
+        });
+      }
+
+      const finalStats = heatbox.getStatistics ? (heatbox.getStatistics() || {}) : {};
+      heatbox.destroy();
+      await nextFrame();
+
+      const times = transitions.map((item) => item.ms);
+      return {
+        version,
+        initMs,
+        avgTransitionMs: times.reduce((sum, value) => sum + value, 0) / times.length,
+        minTransitionMs: Math.min(...times),
+        maxTransitionMs: Math.max(...times),
+        transitions,
+        renderedVoxels: finalStats.renderedVoxels ?? 'n/a',
+        totalVoxels: finalStats.totalVoxels ?? 'n/a'
+      };
+    }
+
+    function renderResults(left, right) {
+      const summary = [
+        ['初期 temporal 初期化', `${left.initMs.toFixed(2)} ms`, `${right.initMs.toFixed(2)} ms`],
+        ['平均時刻ジャンプ', `${left.avgTransitionMs.toFixed(2)} ms`, `${right.avgTransitionMs.toFixed(2)} ms`],
+        ['最小時刻ジャンプ', `${left.minTransitionMs.toFixed(2)} ms`, `${right.minTransitionMs.toFixed(2)} ms`],
+        ['最大時刻ジャンプ', `${left.maxTransitionMs.toFixed(2)} ms`, `${right.maxTransitionMs.toFixed(2)} ms`],
+        ['Rendered Voxels', escapeHtml(left.renderedVoxels), escapeHtml(right.renderedVoxels)],
+        ['Total Voxels', escapeHtml(left.totalVoxels), escapeHtml(right.totalVoxels)]
+      ];
+
+      const summaryRows = summary.map(([name, a, b]) => `
+        <tr>
+          <td>${name}</td>
+          <td>${a}</td>
+          <td>${b}</td>
+        </tr>
+      `).join('');
+
+      const detailRows = left.transitions.map((item, index) => {
+        const other = right.transitions[index];
+        return `
+          <tr>
+            <td class="hb-muted">Hour ${item.hour}</td>
+            <td>${item.ms.toFixed(2)} ms (${escapeHtml(item.totalEntities)}e, ${escapeHtml(item.renderedVoxels)}/${escapeHtml(item.totalVoxels)})</td>
+            <td>${other.ms.toFixed(2)} ms (${escapeHtml(other.totalEntities)}e, ${escapeHtml(other.renderedVoxels)}/${escapeHtml(other.totalVoxels)})</td>
+          </tr>
+        `;
+      }).join('');
+
+      resultsEl.innerHTML = `
+        <table>
+          <thead>
+            <tr>
+              <th>Metric</th>
+              <th>1.2.1</th>
+              <th>1.3.4</th>
+            </tr>
+          </thead>
+          <tbody>${summaryRows}${detailRows}</tbody>
+        </table>
+      `;
+    }
+
+    prepareBtn.addEventListener('click', async () => {
+      try {
+        await prepareScenario();
+      } catch (error) {
+        console.error(error);
+        setStatus(`準備失敗: ${error.message}`, true);
+      }
+    });
+
+    compareBtn.addEventListener('click', async () => {
+      try {
+        compareBtn.disabled = true;
+        resultsEl.innerHTML = '';
+        const scenario = currentScenario || await prepareScenario();
+        const hours = parseHours();
+        if (hours.length === 0) {
+          throw new Error('Hours に 0-23 の値をカンマ区切りで指定してください');
+        }
+
+        setStatus('1.2.1 temporal を計測中...');
+        const left = await measureTemporalVersion('1.2.1', scenario, hours);
+        setStatus('1.3.4 temporal を計測中...');
+        const right = await measureTemporalVersion('1.3.4', scenario, hours);
+        renderResults(left, right);
+        setStatus(
+          `temporal 比較完了\n1.2.1 avg=${left.avgTransitionMs.toFixed(2)} ms\n1.3.4 avg=${right.avgTransitionMs.toFixed(2)} ms`
+        );
+      } catch (error) {
+        console.error(error);
+        setStatus(`比較失敗: ${error.message}`, true);
+      } finally {
+        compareBtn.disabled = false;
+      }
+    });
+
+    showCzmlCheckbox.addEventListener('change', () => {
+      setCzmlVisibility(showCzmlCheckbox.checked);
+    });
+
+    window.addEventListener('load', () => {
+      void prepareScenario();
+    });
+  </script>
+</body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cesium-heatbox",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cesium-heatbox",
-      "version": "1.3.4",
+      "version": "1.3.5",
       "license": "MIT",
       "dependencies": {
         "simple-statistics": "^7.8.8"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cesium-heatbox",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "3D voxel-based heatmap visualization library for CesiumJS",
   "main": "dist/cesium-heatbox.umd.min.js",
   "module": "dist/cesium-heatbox.min.js",

--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,7 @@ export { Heatbox as CesiumHeatbox };
  * Library metadata.
  * ライブラリのメタ情報。
  */
-export const VERSION = '1.3.4';
+export const VERSION = '1.3.5';
 export const AUTHOR = 'hiro-nyon';
 export const REPOSITORY = 'https://github.com/hiro-nyon/cesium-heatbox';
 


### PR DESCRIPTION
## Summary
- add observability and temporal version comparison demos for CDN-based 1.2.1 vs 1.3.4 checks
- record the measured benchmark notes in the v1.3.5 release notes and bump package metadata to 1.3.5
- keep the work split into focused commits for observability, temporal, and release documentation

## Details
- observability compare waits for setData() completion and reports rendered/total voxels with deterministic seeded inputs
- temporal compare drives viewer.clock.currentTime over shared CZML-backed slices and waits for matching totalEntities before recording transition timings
- README entries were added so both demo entry points are discoverable from the examples directories

## Validation
- browser-level smoke check for the observability compare page
- browser-level smoke check for the temporal compare page
- full lint/test/build not run in this pass