### PR TITLE
fix(release): allow npm trusted publishing via OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '24'
-          registry-url: 'https://registry.npmjs.org'
           package-manager-cache: false
       
       - name: Install dependencies
@@ -193,7 +192,7 @@ jobs:
           VERSION=${{ steps.meta.outputs.version }}
           echo "Publishing version $VERSION"
           if [[ "$VERSION" == *-alpha.* || "$VERSION" == *-beta.* || "$VERSION" == *-rc.* ]]; then
-            npm publish --tag next
+            npm publish --provenance --tag next
           else
-            npm publish
+            npm publish --provenance
           fi

--- a/docs/RELEASE_RUNBOOK.md
+++ b/docs/RELEASE_RUNBOOK.md
@@ -63,10 +63,11 @@ git push origin --tags
 
 ファイル: `.github/workflows/release.yml`
 - `push.tags: [ 'v*' ]` で `v0.1.10` や `v0.1.10-alpha.0` の push をトリガに実行。
-- 版文字列に `-alpha.`/`-beta.`/`-rc.` を含む場合は `npm publish --tag next`、それ以外は `npm publish`。
+- 版文字列に `-alpha.`/`-beta.`/`-rc.` を含む場合は `npm publish --provenance --tag next`、それ以外は `npm publish --provenance`。
 - npm Trusted Publishing を使用するため、長期保存する `NPM_TOKEN` は不要。
 - npm 側の Trusted Publisher は `hiro-nyon/cesium-heatbox` の `release.yml` に限定する。
 - Workflow の `id-token: write` 権限により、公開時だけ有効な OIDC 資格情報を取得する。
+- `actions/setup-node` では `registry-url` を指定しない。従来認証用 `.npmrc` とダミー `NODE_AUTH_TOKEN` が OIDC より優先されるのを防ぐ。
 
 通常 CI: `.github/workflows/ci.yml`
 - `main`/`next` への push と PR で、Install→Test→Build→`npm pack --dry-run` まで実施。

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -1698,12 +1698,11 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
-          registry-url: 'https://registry.npmjs.org'
           package-manager-cache: false
       - run: npm ci
       - run: npm run build:all
       - run: npm test:all
-      - run: npm publish
+      - run: npm publish --provenance
       - uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cesium-heatbox",
-  "version": "1.3.7-alpha.0",
+  "version": "1.3.7-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cesium-heatbox",
-      "version": "1.3.7-alpha.0",
+      "version": "1.3.7-alpha.1",
       "license": "MIT",
       "dependencies": {
         "simple-statistics": "^7.8.8"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cesium-heatbox",
-  "version": "1.3.7-alpha.0",
+  "version": "1.3.7-alpha.1",
   "description": "3D voxel-based heatmap visualization library for CesiumJS",
   "main": "dist/cesium-heatbox.cjs",
   "module": "dist/cesium-heatbox.min.mjs",
@@ -8,7 +8,7 @@
   "browser": "dist/cesium-heatbox.umd.min.js",
   "sideEffects": false,
   "bin": {
-    "cesium-heatbox-install-ouranos": "./tools/install-ouranos.js"
+    "cesium-heatbox-install-ouranos": "tools/install-ouranos.js"
   },
   "files": [
     "dist/",
@@ -63,7 +63,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/hiro-nyon/cesium-heatbox.git"
+    "url": "git+https://github.com/hiro-nyon/cesium-heatbox.git"
   },
   "bugs": {
     "url": "https://github.com/hiro-nyon/cesium-heatbox/issues"

--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,7 @@ export { Heatbox as CesiumHeatbox };
  * Library metadata.
  * ライブラリのメタ情報。
  */
-export const VERSION = '1.3.7-alpha.0';
+export const VERSION = '1.3.7-alpha.1';
 export const AUTHOR = 'hiro-nyon';
 export const REPOSITORY = 'https://github.com/hiro-nyon/cesium-heatbox';
 


### PR DESCRIPTION
## Summary
- stop setup-node from generating legacy token authentication config
- publish with explicit npm provenance through OIDC
- normalize repository and bin package metadata
- prepare v1.3.7-alpha.1 because alpha.0 was tagged but not published

## Validation
- npm run -s lint
- npm run -s type-check
- npm test --silent -- --reporters=summary --bail=1
- npm run build
- npm pack --dry-run --json