### PR TITLE
fix: address audit findings and release publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: cesium-heatbox
     steps:
       # next の柔軟なチェックアウト戦略を採用
       - name: Checkout (event ref)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Cesium `PropertyBag` を使うクリック選択と差分描画時の太枠エンティティ回収を修正しました。
+- temporal global classification を実際のボクセル件数ドメインに統一し、Spatial ID QA metrics を統計へ自動反映しました。
+- `maxRenderVoxels`、TopN style、coverage/hybrid 選択、`fitView` オプションの境界処理を修正しました。
+- CommonJS/ESM の条件付き型定義と実行時 export を一致させ、ビルド生成物とサンプルリンクを整理しました。
+- npm Trusted Publishing 用に release job の GitHub Environment を `cesium-heatbox` へ設定しました。
+
 ## [1.3.6] - 2026-04-13
 
 ### Changed
@@ -560,7 +567,7 @@ v0.1系における適応的可視化機能の仕上げバージョン。Phase 0
 - **TopN強調表示**: `highlightTopN` オプションで密度上位Nボクセルのみを強調表示。`highlightStyle` でアウトライン幅や不透明度の調整が可能。
 
 ### Deprecated
-- **batchMode非推奨化**: `batchMode: 'auto'` オプションは非推奨化され、`debug` 時に警告を表示。v1.0.0で削除予定。
+- **batchMode非推奨化**: `batchMode: 'auto'` オプションは非推奨化され、`debug` 時に警告を表示。互換性維持のため v2.0.0 まで保持予定。
 
 ### Changed
 - **Logger拡張**: `Logger.setLogLevel()` が `debug` オプションのオブジェクト形式に対応。互換性を保ちつつ拡張。

--- a/README.ja.md
+++ b/README.ja.md
@@ -155,7 +155,7 @@ const heatbox = new Heatbox(viewer, {
 - `dataSource(currentTime, context)` で lazy loading を追加可能
 - `useWorker: true` で補間と時系列統計の前処理を worker に逃がせます
 - デモは baseline 再生、Global/Per-Time 比較、シナリオ切替、補間/lazy loading の拡張フローまで含みます
-- デモ: `examples/temporal/`
+- デモ: `examples/temporal/README.md`
 
 詳細は[APIリファレンス — 時系列](docs/API.md)を参照してください。
 
@@ -216,7 +216,7 @@ console.log(stats.spatialIdProvider); // "ouranos-gex" または "fallback"
 - ±85.0511°（Web Mercator限界）内で正常動作
 - 日付変更線対応: 将来バージョンで実装予定
 
-詳細は[空間ID使用例](examples/spatial-id/)を参照してください。
+詳細は[空間ID使用例](examples/spatial-id/README.md)を参照してください。
 
 </details>
 
@@ -263,7 +263,7 @@ aggregation: {
 - メモリ: ボクセルあたりのユニークレイヤあたり ~8–16バイト
 - 処理時間: 有効時 ≤ +10%オーバーヘッド、無効時オーバーヘッドなし
 
-詳細は[集約使用例](examples/aggregation/)を参照してください。
+詳細は[集約使用例](examples/aggregation/README.md)を参照してください。
 
 </details>
 
@@ -304,13 +304,13 @@ aggregation: {
 
 | カテゴリ | 説明 | 場所 |
 |----------|------|------|
-| Basic | はじめに | `examples/basic/` |
-| Classification | 色分けスキームデモ | `examples/advanced/` |
-| Temporal | 時系列データ | `examples/temporal/` |
-| Spatial ID | タイルグリッドモード | `examples/spatial-id/` |
-| Aggregation | レイヤ内訳 | `examples/aggregation/` |
-| Rendering | ワイヤーフレーム、高さベース | `examples/rendering/` |
-| Performance | 適応制御、オーバーレイ | `examples/observability/` |
+| Basic | はじめに | `examples/basic/index.html` |
+| Classification | 色分けスキームデモ | `examples/advanced/README.md` |
+| Temporal | 時系列データ | `examples/temporal/README.md` |
+| Spatial ID | タイルグリッドモード | `examples/spatial-id/README.md` |
+| Aggregation | レイヤ内訳 | `examples/aggregation/README.md` |
+| Rendering | ワイヤーフレーム、高さベース | `examples/rendering/README.md` |
+| Performance | 適応制御、オーバーレイ | `examples/observability/README.md` |
 
 ## ドキュメント
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ const heatbox = new Heatbox(viewer, {
 - `dataSource(currentTime, context)` can lazily provide additional temporal slices
 - `useWorker: true` offloads interpolation and temporal stats preprocessing when workers are available
 - Demos cover baseline playback, global/per-time comparison, scenario simulation, and advanced interpolation/lazy-loading flows
-- Demos: `examples/temporal/`
+- Demos: `examples/temporal/README.md`
 
 See [API Reference — Temporal](docs/API.md) for full details.
 
@@ -216,7 +216,7 @@ console.log(stats.spatialIdProvider); // "ouranos-gex" or "fallback"
 - Operates within ±85.0511° latitude (Web Mercator limit)
 - Antimeridian crossing: planned for a future release
 
-See [Spatial ID Examples](examples/spatial-id/) for details.
+See [Spatial ID Examples](examples/spatial-id/README.md) for details.
 
 </details>
 
@@ -263,7 +263,7 @@ aggregation: {
 - Memory: ~8–16 bytes per unique layer per voxel
 - Processing: ≤ +10% overhead when enabled; zero overhead when disabled
 
-See [Aggregation Examples](examples/aggregation/) for details.
+See [Aggregation Examples](examples/aggregation/README.md) for details.
 
 </details>
 
@@ -304,13 +304,13 @@ See [API Reference](docs/API.md) for complete options and method documentation.
 
 | Category | Description | Location |
 |----------|-------------|----------|
-| Basic | Getting started | `examples/basic/` |
-| Classification | Color scheme demos | `examples/advanced/` |
-| Temporal | Time-dependent data | `examples/temporal/` |
-| Spatial ID | Tile-grid mode | `examples/spatial-id/` |
-| Aggregation | Layer breakdown | `examples/aggregation/` |
-| Rendering | Wireframe, height-based | `examples/rendering/` |
-| Performance | Adaptive, overlay | `examples/observability/` |
+| Basic | Getting started | `examples/basic/index.html` |
+| Classification | Color scheme demos | `examples/advanced/README.md` |
+| Temporal | Time-dependent data | `examples/temporal/README.md` |
+| Spatial ID | Tile-grid mode | `examples/spatial-id/README.md` |
+| Aggregation | Layer breakdown | `examples/aggregation/README.md` |
+| Rendering | Wireframe, height-based | `examples/rendering/README.md` |
+| Performance | Adaptive, overlay | `examples/observability/README.md` |
 
 ## Documentation
 

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -353,7 +353,8 @@ Closes #123
   "name": "cesium-heatbox",           // パッケージ名
   "version": "0.1.0",                // バージョン
   "description": "3D heatmap library", // 説明
-  "main": "dist/cesium-heatbox.js",  // メインファイル
+  "main": "dist/cesium-heatbox.cjs", // CommonJSメインファイル
+  "module": "dist/cesium-heatbox.min.mjs",
   "scripts": {                        // 実行可能コマンド
     "dev": "webpack serve --mode development",
     "build": "webpack --mode production",
@@ -645,11 +646,10 @@ ls -la dist/
 du -h dist/*
 
 # 生成されたファイル
-# - cesium-heatbox.js      (開発版)
 # - cesium-heatbox.min.mjs  (ESM本番版・最適化済み)
 # - cesium-heatbox.cjs     (CommonJS本番版)
-# - cesium-heatbox.umd.js  (UMD版)
-# - cesium-heatbox.d.ts    (TypeScript型定義)
+# - cesium-heatbox.umd.min.js (UMD本番版)
+# 型定義は types/index.d.* に生成
 ```
 
 ---

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -188,10 +188,8 @@ npm run build
 ```
 
 Output files:
-- `dist/cesium-heatbox.js` - ESM development version
 - `dist/cesium-heatbox.min.mjs` - ESM production version
 - `dist/cesium-heatbox.cjs` - CommonJS production version
-- `dist/cesium-heatbox.umd.js` - UMD development version
 - `dist/cesium-heatbox.umd.min.js` - UMD production version
 
 ### Release
@@ -426,10 +424,8 @@ npm run build
 ```
 
 出力ファイル:
-- `dist/cesium-heatbox.js` - ESM開発版
 - `dist/cesium-heatbox.min.mjs` - ESM本番版
 - `dist/cesium-heatbox.cjs` - CommonJS本番版
-- `dist/cesium-heatbox.umd.js` - UMD開発版
 - `dist/cesium-heatbox.umd.min.js` - UMD本番版
 
 ## リリース

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -82,10 +82,9 @@ ls -la dist/
 **Expected output:**
 ```
 dist/
-├── cesium-heatbox.js
 ├── cesium-heatbox.min.mjs
 ├── cesium-heatbox.cjs
-└── cesium-heatbox.umd.js
+└── cesium-heatbox.umd.min.js
 ```
 
 #### Sample Execution (2 minutes)
@@ -280,7 +279,7 @@ Experience v0.1.9 features with the comprehensive demo:
 
 ```bash
 # Open advanced demo
-open examples/selection-limits/adaptive-rendering-demo.html
+open examples/selection-limits/adaptive-rendering/index.html
 ```
 
 The demo includes:
@@ -488,10 +487,9 @@ ls -la dist/
 **期待される出力**:
 ```
 dist/
-├── cesium-heatbox.js
 ├── cesium-heatbox.min.mjs
 ├── cesium-heatbox.cjs
-└── cesium-heatbox.umd.js
+└── cesium-heatbox.umd.min.js
 ```
 
 ---

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -390,7 +390,7 @@ import { generateTestEntities } from 'cesium-heatbox';
 ##### UMD（レガシー対応）
 ```html
 <!-- ブラウザ直接読み込み -->
-<script src="cesium-heatbox.umd.js"></script>
+<script src="cesium-heatbox.umd.min.js"></script>
 <script>
   const heatbox = new CesiumHeatbox(viewer);
 </script>
@@ -523,7 +523,7 @@ module.exports = (env, argv) => {
       path: path.resolve(__dirname, 'dist'),
       filename: isProduction ? 
         'cesium-heatbox.umd.min.js' :
-        'cesium-heatbox.umd.js',
+        'cesium-heatbox.umd.min.js',
       library: {
         name: 'CesiumHeatbox',
         type: 'umd',
@@ -918,13 +918,13 @@ cesium-heatbox/
 │       ├── validation.js
 │       └── constants.js
 ├── dist/                      # ビルド出力
-│   ├── cesium-heatbox.js
 │   ├── cesium-heatbox.min.mjs
 │   ├── cesium-heatbox.cjs
-│   ├── cesium-heatbox.umd.js
-│   └── cesium-heatbox.d.ts
+│   └── cesium-heatbox.umd.min.js
 ├── types/                     # TypeScript型定義
-│   └── index.d.ts
+│   ├── index.d.ts
+│   ├── index.d.mts
+│   └── index.d.cts
 ├── test/                      # テストコード
 │   ├── Heatbox.test.js
 │   ├── integration/
@@ -1013,7 +1013,7 @@ npm run benchmark
       "types": "./types/index.d.ts",
       "import": "./dist/cesium-heatbox.min.mjs",
       "require": "./dist/cesium-heatbox.cjs",
-      "default": "./dist/cesium-heatbox.min.mjs"
+      "default": "./dist/cesium-heatbox.cjs"
     }
   }
 }

--- a/examples/advanced/README.md
+++ b/examples/advanced/README.md
@@ -6,11 +6,11 @@
 
 | Category / カテゴリ | Directory | 主なファイル / Key Files |
 | --- | --- | --- |
-| Observability（観測可能性・メトリクス） | `../observability/` | `performance-overlay-demo.html`, `adaptive-phase3-demo.html` |
-| Rendering（描画モード・高さ表現） | `../rendering/` | `wireframe-height-demo-umd.html`, `wireframe-height-demo.js`, `v0.1.12-features-demo.html` |
+| Observability（観測可能性・メトリクス） | `../observability/` | `performance-overlay/index.html`, `adaptive-phase3/index.html` |
+| Rendering（描画モード・高さ表現） | `../rendering/` | `wireframe-height/index.html`, `v0.1.12-features/index.html` |
 | Classification（分類エンジン） | `.` | `classification-demo.html` (v1.0.0), `classification-extension-demo.html` *(v1.1.0 追加)* |
-| Outlines（枠線・エミュレーション） | `../outlines/` | `outline-overlap-demo-umd.html`, `emulation-scope-demo.html`, `../advanced/emulation-opacity-demo.html` *(v1.1.0)* |
-| Selection & Limits（選択戦略・描画上限） | `../selection-limits/` | `adaptive-rendering-demo.html`, `adaptive-rendering-demo.js`, `performance-optimization.js`, `selection-strategy-demo.html` *(new)* |
+| Outlines（枠線・エミュレーション） | `../outlines/` | `outline-overlap/index.html`, `emulation-scope/index.html`, `emulation-opacity-demo.html` |
+| Selection & Limits（選択戦略・描画上限） | `../selection-limits/` | `adaptive-rendering/index.html`, `performance-optimization/performance-optimization.js`, `selection-strategy/index.html` |
 | Data（データ生成・フィルタリング） | `../data/` | `entity-filtering.js` |
 
 ## Usage Notes / 利用時の注意

--- a/examples/observability/README.md
+++ b/examples/observability/README.md
@@ -6,8 +6,8 @@
 
 | File | 概要 |
 | --- | --- |
-| `performance-overlay-demo.html` | パフォーマンスオーバーレイの表示とベンチマーク実行。プロファイル別の比較が可能。 |
-| `adaptive-phase3-demo.html` | ADR-0011 Phase 3 の適応制御デモ。密度検出・重なり検知・拡張オーバーレイを搭載。 |
+| `performance-overlay/index.html` | パフォーマンスオーバーレイの表示とベンチマーク実行。プロファイル別の比較が可能。 |
+| `adaptive-phase3/index.html` | ADR-0011 Phase 3 の適応制御デモ。密度検出・重なり検知・拡張オーバーレイを搭載。 |
 | `version-compare-demo.html` | CDN 上の `1.2.1` と `1.3.4` を同一データで比較する A/B ベンチ。 |
 
 ## Cesium Setup / Cesium 初期化
@@ -19,7 +19,7 @@
 ## How to Run / 実行方法
 
 1. `npm install` 済みのリポジトリで `npx http-server examples/observability` を実行するか、任意の静的サーバーで公開します。
-2. ブラウザで `performance-overlay-demo.html`、`adaptive-phase3-demo.html`、または `version-compare-demo.html` にアクセスします。
+2. ブラウザで `performance-overlay/index.html`、`adaptive-phase3/index.html`、または `version-compare-demo.html` にアクセスします。
 3. UI からプロファイル変更、ボクセル数調整、オーバーレイの表示切替などを行い、ログはブラウザコンソールで確認できます。
 
 ## Notes / 補足

--- a/examples/outlines/README.md
+++ b/examples/outlines/README.md
@@ -6,8 +6,8 @@
 
 | File | 概要 |
 | --- | --- |
-| `outline-overlap-demo-umd.html` | `voxelGap` / `outlineOpacity` / 適応枠線プリセットの比較デモ。ブラウザで直接実行可能。 |
-| `emulation-scope-demo.html` *(new)* | `outlineRenderMode` と `emulationScope` の組み合わせ比較（TopN/Non-TopN/All）。 |
+| `outline-overlap/index.html` | `voxelGap` / `outlineOpacity` / 適応枠線プリセットの比較デモ。 |
+| `emulation-scope/index.html` | `outlineRenderMode` と `emulationScope` の組み合わせ比較（TopN/Non-TopN/All）。 |
 
 ## Cesium Setup / Cesium 初期化
 
@@ -17,8 +17,7 @@
 
 ## Usage / 使い方
 
-- `outline-overlap-demo-umd.html` はブラウザで直接実行できます。
-- `emulation-scope-demo.html` も UMD 版として実装されているため、同様にローカルで開くだけで比較が可能です。
+- `outline-overlap/index.html` と `emulation-scope/index.html` をローカルサーバー経由で開いてください。
 - UI から `outlineRenderMode` や `emulationScope` を切り替え、密度や TopN ハイライトとの相互作用を観察してください。
 
 ## Notes / 補足

--- a/examples/rendering/README.md
+++ b/examples/rendering/README.md
@@ -6,9 +6,9 @@
 
 | File | 概要 |
 | --- | --- |
-| `wireframe-height-demo-umd.html` | UMD 版。`wireframeOnly` / `heightBased` を組み合わせた視覚比較。 |
-| `wireframe-height-demo.js` | モジュール版。複数モードを切り替えるユーティリティクラス。 |
-| `v0.1.12-features-demo.html` | v0.1.12 で追加された `outlineRenderMode` / `emulationScope` / `profile` 等をまとめて確認。 |
+| `wireframe-height/index.html` | UMD 版。`wireframeOnly` / `heightBased` を組み合わせた視覚比較。 |
+| `wireframe-height/wireframe-height-demo.js` | 複数モードを切り替えるユーティリティクラス。 |
+| `v0.1.12-features/index.html` | v0.1.12 で追加された `outlineRenderMode` / `emulationScope` / `profile` 等をまとめて確認。 |
 
 ## Cesium Setup / Cesium 初期化
 
@@ -18,9 +18,9 @@
 
 ## Usage / 使い方
 
-- `wireframe-height-demo-umd.html` はダブルクリックでブラウザにドラッグ＆ドロップするだけで動作します。
-- モジュール版 (`wireframe-height-demo.js`) を試す場合は簡易サーバーを立て、`<script type="module">` からクラスをインポートしてください。
-- `v0.1.12-features-demo.html` では UI から `outlineRenderMode`／`emulationScope`／`profile` を変更し、描画差分を確認できます。
+- `wireframe-height/index.html` はローカルサーバー経由で実行できます。
+- `wireframe-height/wireframe-height-demo.js` を試す場合は簡易サーバーを立ててください。
+- `v0.1.12-features/index.html` では UI から `outlineRenderMode`／`emulationScope`／`profile` を変更し、描画差分を確認できます。
 
 ## Tips / ヒント
 

--- a/examples/selection-limits/README.md
+++ b/examples/selection-limits/README.md
@@ -6,9 +6,9 @@
 
 | File | 概要 |
 | --- | --- |
-| `adaptive-rendering-demo.html` + `adaptive-rendering-demo.js` | v0.1.9 の適応的レンダリング制限。戦略切替・レンダリング上限・自動ボクセルサイズをUIで体験。 |
-| `performance-optimization.js` | 段階的ロード・品質調整・メモリ計測などパフォーマンス最適化のユーティリティ。 |
-| `selection-strategy-demo.html` *(new)* | density / coverage / hybrid を並列比較する UMD デモ。 |
+| `adaptive-rendering/index.html` | 適応的レンダリング制限、戦略切替、自動ボクセルサイズをUIで体験。 |
+| `performance-optimization/performance-optimization.js` | 段階的ロード・品質調整・メモリ計測のユーティリティ。 |
+| `selection-strategy/index.html` | density / coverage / hybrid を比較する UMD デモ。 |
 
 ## Cesium Setup / Cesium 初期化
 
@@ -19,10 +19,10 @@
 ## Usage / 使い方
 
 1. `npm install` 後に `npx http-server examples/selection-limits` を実行するか、任意の静的サーバーで公開します。
-2. ブラウザで `adaptive-rendering-demo.html` などにアクセスし、UI から戦略や描画上限を変更します。
+2. ブラウザで `adaptive-rendering/index.html` などにアクセスし、UI から戦略や描画上限を変更します。
 3. `performance-optimization.js` を利用する場合はアプリ側でインポートし、`new PerformanceOptimizationDemo(viewer)` を呼び出してください。
 
 ## Tips / ヒント
 
-- `adaptive-rendering-demo.js` 内の `generateSampleData` を差し替えることで独自データでの試験が可能です。
+- `adaptive-rendering/adaptive-rendering-demo.js` 内の `generateSampleData` を差し替えることで独自データでの試験が可能です。
 - Auto Render Budget の挙動を確認する際はブラウザ開発者ツールでログ (`console.log`) を参照してください。

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,5 +1,3 @@
-const isCoverageRun = process.argv.includes('--coverage');
-
 module.exports = {
   testEnvironment: 'jsdom',
   setupFiles: ['<rootDir>/test/setup.js'],
@@ -15,11 +13,9 @@ module.exports = {
     '/test/performance/heatbox-v0.1.9-performance.test.js',
     // Long-running performance regression smoke test remains opt-in.
     '/test/performance/performance-regression.test.js',
-    // Istanbul instrumentation distorts wall-clock microbenchmarks.
-    ...(isCoverageRun ? [
-      '/test/performance/classification-performance.test.js',
-      '/test/performance/aggregation-performance.test.js'
-    ] : [])
+    // Wall-clock microbenchmarks are opt-in and excluded consistently from test/coverage.
+    '/test/performance/classification-performance.test.js',
+    '/test/performance/aggregation-performance.test.js'
   ],
   collectCoverageFrom: [
     'src/**/*.js',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cesium-heatbox",
-  "version": "1.3.7-alpha.1",
+  "version": "1.3.7-alpha.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cesium-heatbox",
-      "version": "1.3.7-alpha.1",
+      "version": "1.3.7-alpha.2",
       "license": "MIT",
       "dependencies": {
         "simple-statistics": "^7.8.8"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cesium-heatbox",
-  "version": "1.3.7-alpha.1",
+  "version": "1.3.7-alpha.2",
   "description": "3D voxel-based heatmap visualization library for CesiumJS",
   "main": "dist/cesium-heatbox.cjs",
   "module": "dist/cesium-heatbox.min.mjs",
@@ -20,8 +20,8 @@
   ],
   "scripts": {
     "dev": "webpack serve --mode development",
-    "build": "npm run build:esm && npm run build:cjs && npm run build:umd && npm run build:types && npm run test:package",
-    "build:esm": "webpack --mode production --env target=esm && webpack --mode production --env target=esm-package",
+    "build": "npm run clean && npm run build:esm && npm run build:cjs && npm run build:umd && npm run build:types && npm run test:package",
+    "build:esm": "webpack --mode production --env target=esm-package",
     "build:cjs": "webpack --mode production --env target=cjs",
     "build:umd": "webpack --mode production --env target=umd",
     "build:types": "node tools/build-types.js",
@@ -43,10 +43,15 @@
   },
   "exports": {
     ".": {
-      "types": "./types/index.d.ts",
-      "import": "./dist/cesium-heatbox.min.mjs",
-      "require": "./dist/cesium-heatbox.cjs",
-      "default": "./dist/cesium-heatbox.min.mjs"
+      "import": {
+        "types": "./types/index.d.mts",
+        "default": "./dist/cesium-heatbox.min.mjs"
+      },
+      "require": {
+        "types": "./types/index.d.cts",
+        "default": "./dist/cesium-heatbox.cjs"
+      },
+      "default": "./dist/cesium-heatbox.cjs"
     }
   },
   "keywords": [

--- a/src/Heatbox.js
+++ b/src/Heatbox.js
@@ -22,6 +22,8 @@ import { getProfileNames, getProfile, applyProfile } from './utils/profiles.js';
 import { PerformanceOverlay } from './utils/performanceOverlay.js';
 import { Legend } from './ui/Legend.js';
 import { TimeController } from './core/temporal/TimeController.js';
+import { resolvePropertyValue } from './utils/cesiumProperty.js';
+import { computeSpatialIdEdgeCaseMetrics } from './core/spatial/SpatialIdQaMetrics.js';
 
 /**
  * @typedef {('mobile-fast'|'desktop-balanced'|'dense-data'|'sparse-data')} ProfileName
@@ -326,8 +328,6 @@ export class Heatbox {
     this._performanceOverlay = null;
     this._lastRenderTime = null;
     this._overlayLastUpdate = 0;
-    this._postRenderListener = null;
-    this._prevFrameTimestamp = null;
     this._postRenderListener = null;
     this._prevFrameTimestamp = null;
     this._legend = null;
@@ -783,6 +783,15 @@ export class Heatbox {
     }
 
     if (classificationOptions.spatialId?.enabled) {
+      if (!this._spatialIdEdgeCaseMetrics && classificationOptions._spatialIdAdapter) {
+        try {
+          this._spatialIdEdgeCaseMetrics = computeSpatialIdEdgeCaseMetrics(
+            classificationOptions._spatialIdAdapter
+          );
+        } catch (error) {
+          Logger.warn('Spatial ID edge-case metrics calculation failed:', error);
+        }
+      }
       this._statistics.spatialIdEnabled = true;
       this._statistics.spatialIdMode = classificationOptions.spatialId.mode;
       this._statistics.spatialIdProvider = classificationOptions._spatialIdProvider || null;
@@ -942,7 +951,12 @@ export class Heatbox {
     }
 
     this.options = validateAndNormalizeOptions({ ...this.options, ...newOptions });
+    Logger.setLogLevel(this.options);
     this.renderer.options = this.options;
+
+    if (newOptions && Object.prototype.hasOwnProperty.call(newOptions, 'spatialId')) {
+      this._spatialIdEdgeCaseMetrics = null;
+    }
 
     if (this.renderer.adaptiveController && typeof this.renderer.adaptiveController.updateOptions === 'function') {
       this.renderer.adaptiveController.updateOptions(this.options);
@@ -975,22 +989,23 @@ export class Heatbox {
     // クリックイベントでInfoBoxを更新
     this._eventHandler.setInputAction(movement => {
       const pickedObject = this.viewer.scene.pick(movement.position);
-      if (Cesium.defined(pickedObject) && pickedObject.id &&
-        pickedObject.id.properties &&
-        pickedObject.id.properties.type === 'voxel') {
+      const currentTime = this.viewer.clock?.currentTime || Cesium.JulianDate.now();
+      const properties = pickedObject?.id?.properties;
+      if (Cesium.defined(pickedObject) && pickedObject.id && properties &&
+        resolvePropertyValue(properties.type, currentTime) === 'voxel') {
         // プロパティからキー値を取得
-        const voxelKey = pickedObject.id.properties.key;
+        const voxelKey = resolvePropertyValue(properties.key, currentTime);
         const voxelInfo = {
-          x: pickedObject.id.properties.x,
-          y: pickedObject.id.properties.y,
-          z: pickedObject.id.properties.z,
-          count: pickedObject.id.properties.count
+          x: resolvePropertyValue(properties.x, currentTime),
+          y: resolvePropertyValue(properties.y, currentTime),
+          z: resolvePropertyValue(properties.z, currentTime),
+          count: resolvePropertyValue(properties.count, currentTime)
         };
 
         // InfoBoxに表示するためのダミーエンティティを作成
         const dummyEntity = new Cesium.Entity({
           id: `voxel-${voxelKey}`,
-          description: this.renderer.createVoxelDescription(voxelInfo, voxelKey)
+          description: this.renderer.geometryRenderer.createVoxelDescription(voxelInfo, voxelKey)
         });
         this.viewer.selectedEntity = dummyEntity;
       }
@@ -1249,7 +1264,15 @@ export class Heatbox {
     const heading = Cesium.Math.toRadians(fitOptions.headingDegrees ?? 0);
     const pitchDeg = Math.max(-85, Math.min(-10, fitOptions.pitchDegrees ?? -35));
     const pitch = Cesium.Math.toRadians(pitchDeg);
-    const range = Math.max(bs.radius * 2.2, 1000.0);
+    const paddingPercent = Number.isFinite(fitOptions.paddingPercent)
+      ? Math.max(0, Math.min(1, fitOptions.paddingPercent))
+      : 0.1;
+    const paddedRadius = bs.radius * (1 + (paddingPercent * 2));
+    const altitudeSpan = Math.max(0, (bounds.maxAlt || 0) - (bounds.minAlt || 0));
+    const baseRange = fitOptions.altitudeStrategy === 'manual'
+      ? paddedRadius * 2.2
+      : Math.max(paddedRadius * 2.2, altitudeSpan * 2.2);
+    const range = Math.max(baseRange, 1000.0);
     await this.viewer.camera.flyToBoundingSphere(bs, {
       duration: 1.2,
       offset: new Cesium.HeadingPitchRange(heading, pitch, range)

--- a/src/core/DataProcessor.js
+++ b/src/core/DataProcessor.js
@@ -294,8 +294,17 @@ export class DataProcessor {
       return emptyStats;
     }
 
-    const counts = Array.from(voxelData.values()).map(voxel => voxel.count);
-    const totalEntities = counts.reduce((sum, count) => sum + count, 0);
+    const counts = [];
+    let totalEntities = 0;
+    let minCount = Infinity;
+    let maxCount = -Infinity;
+    for (const voxel of voxelData.values()) {
+      const count = voxel.count;
+      counts.push(count);
+      totalEntities += count;
+      minCount = Math.min(minCount, count);
+      maxCount = Math.max(maxCount, count);
+    }
 
     // v0.1.17: Spatial ID mode can exceed grid.totalVoxels, clamp emptyVoxels to non-negative
     // 空間IDモードではgrid.totalVoxelsを超える可能性があるため、emptyVoxelsを非負にクランプ
@@ -307,8 +316,8 @@ export class DataProcessor {
       nonEmptyVoxels: voxelData.size,
       emptyVoxels: emptyVoxels,
       totalEntities: totalEntities,
-      minCount: Math.min(...counts),
-      maxCount: Math.max(...counts),
+      minCount,
+      maxCount,
       averageCount: totalEntities / voxelData.size,
       // v0.1.4: 自動調整情報の初期化
       autoAdjusted: false,
@@ -434,6 +443,7 @@ export class DataProcessor {
     // Store zoom level and provider info for statistics / 統計情報用にズームレベルとプロバイダー情報を保存
     options._resolvedZoom = zoom;
     options._spatialIdProvider = adapter.fallbackMode ? null : options.spatialId.provider;
+    options._spatialIdAdapter = adapter;
 
     // v0.1.18: Layer aggregation setup (ADR-0014)
     const aggregationOptions = options.aggregation || {};

--- a/src/core/VoxelRenderer.js
+++ b/src/core/VoxelRenderer.js
@@ -471,7 +471,7 @@ export class VoxelRenderer {
       
       // TopN highlight adjustment 
       if (this.options.highlightTopN && !isTopN) {
-        opacity *= (1 - (this.options.highlightStyle?.boostOpacity || 0.2));
+        opacity *= (1 - (this.options.highlightStyle?.boostOpacity ?? 0.2));
       }
     }
     
@@ -542,9 +542,10 @@ export class VoxelRenderer {
       if (adaptiveParams.outlineWidth !== null && adaptiveParams.outlineWidth !== undefined) {
         finalOutlineWidth = adaptiveParams.outlineWidth;
       } else {
-        finalOutlineWidth = isTopN && this.options.highlightTopN ? 
-          (this.options.highlightStyle?.outlineWidth || this.options.outlineWidth) : 
-          this.options.outlineWidth;
+        finalOutlineWidth = isTopN && this.options.highlightTopN
+          ? (this.options.highlightStyle?.outlineWidth ?? this.options.outlineWidth) +
+            (this.options.highlightStyle?.boostOutlineWidth ?? 0)
+          : this.options.outlineWidth;
       }
     }
 

--- a/src/core/geometry/GeometryRenderer.js
+++ b/src/core/geometry/GeometryRenderer.js
@@ -280,14 +280,17 @@ export class GeometryRenderer {
     this.entities.push(insetEntity);
     
     // 枠線の厚み部分を視覚化（WebGL 1px制限の回避）
+    let frameEntities = [];
     if (this.options.enableThickFrames && (effectiveInsetX > 0.1 || effectiveInsetY > 0.1 || effectiveInsetZ > 0.1)) {
-      this.createThickOutlineFrames({
+      frameEntities = this.createThickOutlineFrames({
         centerLon: safeCenterLon, centerLat: safeCenterLat, centerAlt: safeCenterAlt,
         outerX: safeBaseSizeX, outerY: safeBaseSizeY, outerZ: safeBaseSizeZ,
         innerX: insetSizeX, innerY: insetSizeY, innerZ: insetSizeZ,
         frameColor: outlineColor, voxelKey
       });
     }
+    // Cesium PropertyBag を走査せず、生成元から所有エンティティを直接引き渡す。
+    insetEntity._heatboxFrameEntities = frameEntities;
     
     Logger.debug(`Inset outline created for voxel ${voxelKey}:`, {
       originalSize: { x: baseSizeX, y: baseSizeY, z: baseSizeZ },
@@ -754,10 +757,7 @@ export class GeometryRenderer {
       voxelKey: config.voxelKey,
       insetAmount: this.options.outlineInset > 0 ? this.options.outlineInset : 1
     });
-
-    if (this.options.enableThickFrames) {
-      record.frameEntities = this.entities.filter(entity => entity?.properties?.parentKey === config.voxelKey && String(entity?.properties?.type || '').startsWith('voxel-thick-frame-'));
-    }
+    record.frameEntities = record.insetEntity?._heatboxFrameEntities || [];
   }
 
   _syncPolylineRecord(record, config) {

--- a/src/core/render/buildDisplayVoxels.js
+++ b/src/core/render/buildDisplayVoxels.js
@@ -13,7 +13,7 @@ export function buildDisplayVoxels(voxelData, grid, options, selectVoxels) {
   const gridVoxelCount = getGridVoxelCount(grid);
   const configuredLimit = Number.isFinite(options.maxRenderVoxels) && options.maxRenderVoxels > 0
     ? Math.floor(options.maxRenderVoxels)
-    : 10000;
+    : 50000;
   const canSynthesizeEmptyVoxels = options.showEmptyVoxels && !options.spatialId?.enabled;
   const renderLimit = canSynthesizeEmptyVoxels
     ? Math.min(gridVoxelCount, configuredLimit)

--- a/src/core/selection/VoxelSelector.js
+++ b/src/core/selection/VoxelSelector.js
@@ -104,7 +104,7 @@ export class VoxelSelector {
       this._lastSelectionStats = {
         strategy: result.strategy,
         clippedNonEmpty: result.clippedNonEmpty,
-        coverageRatio: result.coverageRatio || null,
+        coverageRatio: result.coverageRatio ?? null,
         selectedCount: result.selectedVoxels.length,
         totalCount: allVoxels.length
       };
@@ -233,31 +233,26 @@ export class VoxelSelector {
     });
     
     // 各ビンから代表ボクセルを選択
-    const binKeys = Array.from(bins.keys());
+    const binQueues = Array.from(bins.values(), binVoxels =>
+      binVoxels.sort((a, b) => b.info.count - a.info.count)
+    );
     let binIndex = 0;
-    
-    while (selected.length < maxCount && binIndex < binKeys.length * 10) { // 最大10周
-      const binKey = binKeys[binIndex % binKeys.length];
-      const binVoxels = bins.get(binKey);
-      
-      if (binVoxels && binVoxels.length > 0) {
-        // ビン内で最高密度のボクセルを選択
-        binVoxels.sort((a, b) => b.info.count - a.info.count);
-        const voxel = binVoxels.shift();
-        
-        if (!included.has(voxel.key)) {
-          selected.push(voxel);
-          included.add(voxel.key);
-        }
-        
-        // 空になったビンを削除
-        if (binVoxels.length === 0) {
-          bins.delete(binKey);
-          binKeys.splice(binKeys.indexOf(binKey), 1);
-        }
+
+    while (selected.length < maxCount && binQueues.length > 0) {
+      const binVoxels = binQueues[binIndex];
+      const voxel = binVoxels.shift();
+
+      if (voxel && !included.has(voxel.key)) {
+        selected.push(voxel);
+        included.add(voxel.key);
       }
-      
-      binIndex++;
+
+      if (binVoxels.length === 0) {
+        binQueues.splice(binIndex, 1);
+        if (binIndex >= binQueues.length) binIndex = 0;
+      } else {
+        binIndex = (binIndex + 1) % binQueues.length;
+      }
     }
     
     const clippedCount = allVoxels.length - selected.length;
@@ -290,8 +285,10 @@ export class VoxelSelector {
     });
     
     const remainingCount = maxCount - selected.length;
-    const adjustedCoverageCount = Math.floor(remainingCount * minCoverageRatio);
+    const adjustedCoverageCount = Math.ceil(remainingCount * minCoverageRatio);
     const adjustedDensityCount = remainingCount - adjustedCoverageCount;
+    let coverageAdded = 0;
+    let densityAdded = 0;
     
     // カバレッジ選択（層化抽出）
     if (adjustedCoverageCount > 0) {
@@ -306,6 +303,7 @@ export class VoxelSelector {
         if (selected.length < maxCount && !included.has(voxel.key)) {
           selected.push(voxel);
           included.add(voxel.key);
+          coverageAdded++;
         }
       });
     }
@@ -322,13 +320,29 @@ export class VoxelSelector {
         if (selected.length < maxCount && !included.has(voxel.key)) {
           selected.push(voxel);
           included.add(voxel.key);
+          densityAdded++;
         }
+      });
+    }
+
+    if (selected.length < maxCount) {
+      const fillResult = this._selectByDensityStrategy(
+        allVoxels.filter(voxel => !included.has(voxel.key)),
+        maxCount - selected.length,
+        new Set()
+      );
+      fillResult.selectedVoxels.forEach(voxel => {
+        selected.push(voxel);
+        included.add(voxel.key);
+        densityAdded++;
       });
     }
     
     // 実際のカバレッジ比率を計算
-    const actualCoverageRatio = adjustedCoverageCount > 0 ? 
-      (selected.length - forceInclude.size - adjustedDensityCount) / (selected.length - forceInclude.size) : 0;
+    const strategySelectedCount = coverageAdded + densityAdded;
+    const actualCoverageRatio = strategySelectedCount > 0
+      ? coverageAdded / strategySelectedCount
+      : 0;
     
     const clippedCount = allVoxels.length - selected.length;
     return this._createResult(selected, 'hybrid', selected.length, clippedCount, actualCoverageRatio);

--- a/src/core/temporal/TimeController.js
+++ b/src/core/temporal/TimeController.js
@@ -42,16 +42,7 @@ export class TimeController {
         // Global scope: calculate stats once
         if (this._options.classificationScope === 'global') {
             const heatboxOptions = this._heatbox.options || {};
-            const valueProperty = heatboxOptions.valueProperty || 'weight';
-            if (this._options.useWorker) {
-                void this._activateWithAsyncStats(valueProperty, heatboxOptions.classification || null);
-                return;
-            }
-
-            this._heatbox._globalStats = this._slicer.calculateGlobalStats(
-                valueProperty,
-                heatboxOptions.classification || null
-            );
+            return this._activateWithAsyncStats(heatboxOptions.classification || null);
         }
 
         this._bindClockListener();
@@ -61,14 +52,15 @@ export class TimeController {
         this._onTick(this._viewer.clock);
     }
 
-    async _activateWithAsyncStats(valueProperty, classificationOptions) {
+    async _activateWithAsyncStats(classificationOptions) {
         let isCancelled = false;
 
         try {
-            this._heatbox._globalStats = await this._slicer.calculateGlobalStatsAsync(
-                valueProperty,
-                classificationOptions
-            );
+            const heatboxOptions = this._heatbox.options || {};
+            this._heatbox._globalStats = await this._slicer.calculateGlobalVoxelStats({
+                ...heatboxOptions,
+                classification: classificationOptions
+            });
         } finally {
             isCancelled = !this._isActive;
         }
@@ -78,6 +70,7 @@ export class TimeController {
         }
 
         this._bindClockListener();
+        this._bindCameraListener();
         this._onTick(this._viewer.clock);
     }
 

--- a/src/core/temporal/TimeSlicer.js
+++ b/src/core/temporal/TimeSlicer.js
@@ -1,8 +1,14 @@
 import * as Cesium from 'cesium';
 import { DataProcessor } from '../DataProcessor.js';
+import { CoordinateTransformer } from '../CoordinateTransformer.js';
+import { VoxelGrid } from '../VoxelGrid.js';
 import { Logger } from '../../utils/logger.js';
 import { TemporalWorkerBridge } from './TemporalWorkerBridge.js';
-import { calculateTemporalStats, interpolateTemporalData } from './temporalWorkerTasks.js';
+import {
+    calculateTemporalStats,
+    calculateTemporalValueStats,
+    interpolateTemporalData
+} from './temporalWorkerTasks.js';
 
 /**
  * TimeSlicer class for managing and retrieving time-series data.
@@ -536,6 +542,59 @@ export class TimeSlicer {
             );
         }
 
+        this._globalStatsCache[cacheKey] = stats;
+        return stats;
+    }
+
+    /**
+     * Calculate the global classification domain from rendered voxel counts.
+     * 入力プロパティではなく、各時間断面で実際に生成されるボクセル件数を集計します。
+     * @param {Object} heatboxOptions - Normalized Heatbox options
+     * @returns {Promise<Object|null>} Global voxel statistics
+     */
+    async calculateGlobalVoxelStats(heatboxOptions = {}) {
+        const cacheKey = JSON.stringify({
+            mode: 'voxel-counts',
+            voxelSize: heatboxOptions.voxelSize,
+            spatialId: heatboxOptions.spatialId || null,
+            classification: heatboxOptions.classification || null
+        });
+        if (this._globalStatsCache[cacheKey]) {
+            return this._globalStatsCache[cacheKey];
+        }
+
+        const counts = [];
+        for (const entry of this._entries) {
+            if (!Array.isArray(entry.data) || entry.data.length === 0) continue;
+            try {
+                const bounds = CoordinateTransformer.calculateBounds(entry.data);
+                const voxelSize = Number.isFinite(heatboxOptions.voxelSize) && heatboxOptions.voxelSize > 0
+                    ? heatboxOptions.voxelSize
+                    : 20;
+                const grid = VoxelGrid.createGrid(bounds, voxelSize);
+                const voxelData = await DataProcessor.classifyEntitiesIntoVoxels(
+                    entry.data,
+                    bounds,
+                    grid,
+                    { ...heatboxOptions, voxelSize }
+                );
+                for (const voxel of voxelData.values()) counts.push(voxel.count);
+            } catch (error) {
+                Logger.warn('Temporal global voxel classification skipped an invalid entry:', error);
+            }
+        }
+
+        const stats = calculateTemporalValueStats(counts);
+        if (!stats) return null;
+
+        if (heatboxOptions.classification?.enabled) {
+            stats.classification = DataProcessor._buildClassificationStats(
+                counts,
+                heatboxOptions.classification,
+                stats.minCount,
+                stats.maxCount
+            );
+        }
         this._globalStatsCache[cacheKey] = stats;
         return stats;
     }

--- a/src/core/temporal/temporalWorkerTasks.js
+++ b/src/core/temporal/temporalWorkerTasks.js
@@ -79,10 +79,6 @@ export function calculateTemporalQuantiles(sortedValues, quantiles) {
 }
 
 export function calculateTemporalStats(entries = [], valueProperty = 'weight') {
-  let min = Infinity;
-  let max = -Infinity;
-  let sum = 0;
-  let count = 0;
   const allValues = [];
 
   for (const entry of entries) {
@@ -92,19 +88,24 @@ export function calculateTemporalStats(entries = [], valueProperty = 'weight') {
       const value = point?.[valueProperty] ?? 1;
       if (typeof value !== 'number') continue;
 
-      min = Math.min(min, value);
-      max = Math.max(max, value);
-      sum += value;
-      count++;
       allValues.push(value);
     }
   }
 
-  if (count === 0) {
+  return calculateTemporalValueStats(allValues);
+}
+
+export function calculateTemporalValueStats(values = []) {
+  if (values.length === 0) {
     return null;
   }
 
-  allValues.sort((a, b) => a - b);
+  const allValues = [...values].sort((a, b) => a - b);
+  let sum = 0;
+  for (const value of allValues) sum += value;
+  const count = allValues.length;
+  const min = allValues[0];
+  const max = allValues[count - 1];
 
   return {
     min,

--- a/src/index.js
+++ b/src/index.js
@@ -3,8 +3,8 @@
  * CesiumJS Heatbox - エントリーポイント。
  */
 
+import * as Cesium from 'cesium';
 import { Heatbox } from './Heatbox.js';
-import { Logger } from './utils/logger.js';
 import { getAllEntities, generateTestEntities } from './utils/sampleData.js';
 import { Legend } from './ui/Legend.js';
 
@@ -23,7 +23,7 @@ export { Heatbox as CesiumHeatbox };
  * Library metadata.
  * ライブラリのメタ情報。
  */
-export const VERSION = '1.3.7-alpha.1';
+export const VERSION = '1.3.7-alpha.2';
 export const AUTHOR = 'hiro-nyon';
 export const REPOSITORY = 'https://github.com/hiro-nyon/cesium-heatbox';
 
@@ -64,6 +64,3 @@ export function getEnvironmentInfo() {
     timestamp: new Date().toISOString()
   };
 }
-
-// ライブラリの初期化ログ
-Logger.info(`CesiumJS Heatbox v${VERSION} loaded`);

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -29,7 +29,8 @@ export const DEFAULT_OPTIONS = {
   highlightTopN: null, // トップN強調表示（null: 無効）
   highlightStyle: {
     outlineWidth: 4,
-    boostOpacity: 0.2
+    boostOpacity: 0.2,
+    boostOutlineWidth: 0
   },
   // v0.1.6: 枠線重なり対策・柔軟化
   voxelGap: 0, // ボクセル間ギャップ（メートル）

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -206,7 +206,7 @@ export function validateAndNormalizeOptions(options = {}) {
   
   // v0.1.5: batchMode非推奨化警告（debug時のみ）
   if (normalized.batchMode && normalized.debug) {
-    Logger.warn('batchMode option is deprecated and will be removed in v1.0.0. It is currently ignored.');
+    Logger.warn('batchMode option is deprecated and will be removed in v2.0.0. It is currently ignored.');
   }
   
   // ボクセルサイズのバリデーション
@@ -245,6 +245,36 @@ export function validateAndNormalizeOptions(options = {}) {
     if (typeof normalized.highlightTopN !== 'number' || normalized.highlightTopN <= 0) {
       Logger.warn(`Invalid highlightTopN: ${normalized.highlightTopN}. Must be a positive number.`);
       normalized.highlightTopN = null;
+    }
+  }
+
+  const highlightStyle = normalized.highlightStyle && typeof normalized.highlightStyle === 'object'
+    ? normalized.highlightStyle
+    : {};
+  normalized.highlightStyle = {
+    ...DEFAULT_OPTIONS.highlightStyle,
+    ...highlightStyle
+  };
+  const highlightOutlineWidth = parseFloat(normalized.highlightStyle.outlineWidth);
+  normalized.highlightStyle.outlineWidth = Number.isFinite(highlightOutlineWidth)
+    ? Math.max(0.5, Math.min(20, highlightOutlineWidth))
+    : DEFAULT_OPTIONS.highlightStyle.outlineWidth;
+  const boostOpacity = parseFloat(normalized.highlightStyle.boostOpacity);
+  normalized.highlightStyle.boostOpacity = Number.isFinite(boostOpacity)
+    ? Math.max(0, Math.min(1, boostOpacity))
+    : DEFAULT_OPTIONS.highlightStyle.boostOpacity;
+  const boostOutlineWidth = parseFloat(normalized.highlightStyle.boostOutlineWidth);
+  normalized.highlightStyle.boostOutlineWidth = Number.isFinite(boostOutlineWidth)
+    ? Math.max(0, Math.min(20, boostOutlineWidth))
+    : DEFAULT_OPTIONS.highlightStyle.boostOutlineWidth;
+
+  if (normalized.maxRenderVoxels !== undefined && normalized.maxRenderVoxels !== 'auto') {
+    const maxRenderVoxels = Number(normalized.maxRenderVoxels);
+    if (!Number.isFinite(maxRenderVoxels) || maxRenderVoxels <= 0) {
+      Logger.warn(`Invalid maxRenderVoxels: ${normalized.maxRenderVoxels}. Using ${DEFAULT_OPTIONS.maxRenderVoxels}.`);
+      normalized.maxRenderVoxels = DEFAULT_OPTIONS.maxRenderVoxels;
+    } else {
+      normalized.maxRenderVoxels = Math.max(1, Math.floor(maxRenderVoxels));
     }
   }
   

--- a/test/Heatbox.test.js
+++ b/test/Heatbox.test.js
@@ -4,6 +4,8 @@
 /* global document */
 
 import { Heatbox } from '../src/Heatbox.js';
+import { Logger } from '../src/utils/logger.js';
+import * as Cesium from 'cesium';
 
 describe('Heatbox', () => {
   let viewer;
@@ -126,6 +128,21 @@ describe('Heatbox', () => {
     });
   });
 
+  describe('クリック選択', () => {
+    test('Cesium PropertyBag のボクセルをInfoBoxへ選択できる', () => {
+      const voxel = new Cesium.Entity({
+        properties: { type: 'voxel', key: '1,2,3', x: 1, y: 2, z: 3, count: 7 }
+      });
+      viewer.scene.pick = jest.fn(() => ({ id: voxel }));
+      const handler = heatbox._eventHandler.setInputAction.mock.calls[0][0];
+
+      handler({ position: { x: 10, y: 20 } });
+
+      expect(viewer.selectedEntity.id).toBe('voxel-1,2,3');
+      expect(viewer.selectedEntity.description).toContain('7');
+    });
+  });
+
   describe('カメラ制御', () => {
     test('fitViewはpostRender後にBoundingSphereへ移動する', async () => {
       viewer.camera.flyToBoundingSphere = jest.fn().mockResolvedValue(undefined);
@@ -141,6 +158,19 @@ describe('Heatbox', () => {
 
       expect(viewer.camera.flyToBoundingSphere).toHaveBeenCalledTimes(1);
       expect(viewer.scene.postRender.removeEventListener).toHaveBeenCalledTimes(1);
+    });
+
+    test('fitViewのpaddingPercentとaltitudeStrategyを距離へ反映する', async () => {
+      viewer.camera.flyToBoundingSphere = jest.fn().mockResolvedValue(undefined);
+      const bounds = { ...testUtils.createMockBounds(), maxAlt: 2000 };
+
+      await heatbox._fitByBoundingSphere(bounds, { paddingPercent: 0, altitudeStrategy: 'manual' });
+      const manualRange = viewer.camera.flyToBoundingSphere.mock.calls[0][1].offset.range;
+      await heatbox._fitByBoundingSphere(bounds, { paddingPercent: 0.5, altitudeStrategy: 'auto' });
+      const autoRange = viewer.camera.flyToBoundingSphere.mock.calls[1][1].offset.range;
+
+      expect(manualRange).toBeCloseTo(1100);
+      expect(autoRange).toBeGreaterThan(manualRange);
     });
 
     test('fitViewは境界がない場合と無効な場合に安全に終了する', async () => {
@@ -177,9 +207,12 @@ describe('Heatbox', () => {
     });
     
     test('updateOptionsでオプションを更新できる', () => {
+      const logLevelSpy = jest.spyOn(Logger, 'setLogLevel');
       heatbox.updateOptions({ voxelSize: 50 });
       const options = heatbox.getOptions();
       expect(options.voxelSize).toBe(50);
+      expect(logLevelSpy).toHaveBeenCalledWith(expect.objectContaining({ voxelSize: 50 }));
+      logLevelSpy.mockRestore();
     });
 
     test('autoVoxelSizeはvoxelSize未指定時に推定値を使用する', async () => {

--- a/test/__mocks__/cesium.js
+++ b/test/__mocks__/cesium.js
@@ -179,9 +179,45 @@ const MathUtil = {
 // definedユーティリティ
 const defined = (v) => v !== undefined && v !== null;
 
-// Entityの軽量モック
+class ConstantProperty {
+  constructor(value) {
+    this._value = value;
+  }
+
+  getValue() {
+    return this._value;
+  }
+
+  setValue(value) {
+    this._value = value;
+  }
+}
+
+class PropertyBag {
+  constructor(properties = {}) {
+    Object.entries(properties).forEach(([key, value]) => {
+      this[key] = value && typeof value.getValue === 'function'
+        ? value
+        : new ConstantProperty(value);
+    });
+  }
+
+  getValue() {
+    return Object.fromEntries(Object.entries(this).map(([key, property]) => [
+      key,
+      property && typeof property.getValue === 'function' ? property.getValue() : property
+    ]));
+  }
+}
+
+// Entityの軽量モック（Cesium同様、propertiesはPropertyBagへ変換）
 class Entity {
-  constructor(options) { Object.assign(this, options); }
+  constructor(options = {}) {
+    Object.assign(this, options);
+    if (options.properties && !(options.properties instanceof PropertyBag)) {
+      this.properties = new PropertyBag(options.properties);
+    }
+  }
 }
 
 class Rectangle {
@@ -219,6 +255,8 @@ module.exports = {
   ScreenSpaceEventType,
   defined,
   Entity,
+  ConstantProperty,
+  PropertyBag,
   Rectangle,
   BoundingSphere,
   HeadingPitchRange,

--- a/test/core/VoxelRenderer.test.js
+++ b/test/core/VoxelRenderer.test.js
@@ -381,14 +381,14 @@ describe('VoxelRenderer', () => {
         renderer = new VoxelRenderer(viewer, {
             outlineWidth: 2,
             highlightTopN: 1,
-            highlightStyle: { outlineWidth: 4 }
+            highlightStyle: { outlineWidth: 4, boostOutlineWidth: 1.5 }
         });
         renderer.render(voxelData, bounds, grid, statistics);
 
         const topNVoxelCall = mockAdd.mock.calls.find(call => call[0].properties.key === '0,0,0');
         const otherVoxelCall = mockAdd.mock.calls.find(call => call[0].properties.key === '1,1,1');
 
-        expect(topNVoxelCall[0].box.outlineWidth).toBe(4);
+        expect(topNVoxelCall[0].box.outlineWidth).toBe(5.5);
         expect(otherVoxelCall[0].box.outlineWidth).toBe(2);
     });
   });

--- a/test/core/aggregation.test.js
+++ b/test/core/aggregation.test.js
@@ -722,7 +722,7 @@ describe('String coercion', () => {
         voxelKey: '1-2-3'
       });
 
-      expect(entity.properties.layerTop).toBe('residential');
+      expect(entity.properties.layerTop.getValue()).toBe('residential');
       expect(entity.description).toContain('レイヤ内訳');
       expect(colorStub.withAlpha).toHaveBeenCalledWith(0.8);
     });

--- a/test/core/geometry/GeometryRenderer.test.js
+++ b/test/core/geometry/GeometryRenderer.test.js
@@ -483,6 +483,45 @@ describe('GeometryRenderer', () => {
       expect(mockViewer.entities.remove).toHaveBeenCalled();
       expect(geometryRenderer.entities).toHaveLength(0);
     });
+
+    test('Should track and remove thick frame entities across diff updates', () => {
+      let entityId = 0;
+      mockViewer.entities.add.mockImplementation(config => ({
+        id: `frame-entity-${entityId++}`,
+        ...config,
+        isDestroyed: jest.fn(() => false)
+      }));
+      geometryRenderer.updateOptions({ enableThickFrames: true, outlineInset: 1 });
+      const config = {
+        centerLon: 139.7, centerLat: 35.6, centerAlt: 100,
+        cellSizeX: 10, cellSizeY: 10, boxHeight: 10,
+        color: { withAlpha: jest.fn(alpha => ({ alpha })) },
+        opacity: 0.5,
+        shouldShowOutline: true,
+        outlineColor: { withAlpha: jest.fn(alpha => ({ alpha })) },
+        outlineWidth: 2,
+        voxelInfo: { x: 0, y: 0, z: 0, count: 1 },
+        voxelKey: 'thick-record',
+        emulateThick: false,
+        shouldShowInsetOutline: true,
+        adaptiveParams: {}
+      };
+
+      geometryRenderer.beginFrame();
+      geometryRenderer.syncVoxel(config);
+      geometryRenderer.endFrame();
+      const oldFrames = [...geometryRenderer._records.get('thick-record').frameEntities];
+      expect(oldFrames).toHaveLength(12);
+
+      geometryRenderer.beginFrame();
+      geometryRenderer.syncVoxel(config);
+      geometryRenderer.endFrame();
+
+      oldFrames.forEach(entity => {
+        expect(mockViewer.entities.remove).toHaveBeenCalledWith(entity);
+      });
+      expect(geometryRenderer._records.get('thick-record').frameEntities).toHaveLength(12);
+    });
   });
 
   describe('Configuration Management', () => {

--- a/test/core/selection/VoxelSelector.test.js
+++ b/test/core/selection/VoxelSelector.test.js
@@ -285,7 +285,7 @@ describe('VoxelSelector', () => {
       
       expect(result.strategy).toBe('hybrid');
       // Coverage ratio should be influenced by minCoverageRatio
-      expect(typeof result.coverageRatio).toBe('number');
+      expect(result.coverageRatio).toBeGreaterThanOrEqual(0.5);
     });
     
     test('Should store hybrid statistics correctly', () => {

--- a/test/core/temporal/TimeSlicer.test.js
+++ b/test/core/temporal/TimeSlicer.test.js
@@ -236,6 +236,35 @@ describe('TimeSlicer', () => {
     });
 
     describe('calculateGlobalStats', () => {
+        test('calculateGlobalVoxelStats uses rendered voxel counts instead of point weights', async () => {
+            const data = [
+                {
+                    start: '2025-01-01T00:00:00Z',
+                    stop: '2025-01-01T01:00:00Z',
+                    data: [
+                        { position: { x: 139.7, y: 35.6, z: 10 }, weight: 1000 },
+                        { position: { x: 139.7, y: 35.6, z: 10 }, weight: 2000 },
+                        { position: { x: 139.71, y: 35.61, z: 10 }, weight: 3000 }
+                    ]
+                },
+                {
+                    start: '2025-01-01T01:00:00Z',
+                    stop: '2025-01-01T02:00:00Z',
+                    data: Array.from({ length: 4 }, () => ({
+                        position: { x: 139.72, y: 35.62, z: 20 },
+                        weight: 9999
+                    }))
+                }
+            ];
+            const slicer = new TimeSlicer(data);
+
+            const stats = await slicer.calculateGlobalVoxelStats({ voxelSize: 20 });
+
+            expect(stats.domain).toEqual([1, 4]);
+            expect(stats.minCount).toBe(1);
+            expect(stats.maxCount).toBe(4);
+        });
+
         test('uses provided valueProperty and caches results', () => {
             const data = [
                 {

--- a/test/helpers/testHelpers.js
+++ b/test/helpers/testHelpers.js
@@ -2,6 +2,7 @@
  * Shared test helpers for CesiumJS Heatbox test suite
  * Centralizes common test utilities to reduce code duplication
  */
+import * as Cesium from 'cesium';
 
 /**
  * Create a mock CesiumJS viewer for testing
@@ -29,7 +30,7 @@ export function createMockViewer() {
     entities: {
       values: [],
       add: jest.fn(function(config) {
-        const entity = { id: config.id || 'mock-entity', ...config };
+        const entity = new Cesium.Entity({ id: config.id || 'mock-entity', ...config });
         this.values.push(entity);
         return entity;
       }),

--- a/test/integration/aggregation.test.js
+++ b/test/integration/aggregation.test.js
@@ -5,6 +5,8 @@
 import { Heatbox } from '../../src/Heatbox.js';
 import { createMockViewer } from '../helpers/testHelpers.js';
 
+const entityType = entity => entity.properties?.getValue?.().type ?? entity.properties?.type;
+
 describe('Layer Aggregation Integration (ADR-0014)', () => {
   let viewer;
   let heatbox;
@@ -137,9 +139,7 @@ describe('Layer Aggregation Integration (ADR-0014)', () => {
 
       // Check rendered entities
       const allEntities = Array.from(viewer.entities.values);
-      const renderedEntities = allEntities.filter(e => 
-        e.properties && e.properties.type === 'voxel'
-      );
+      const renderedEntities = allEntities.filter(e => entityType(e) === 'voxel');
 
       expect(renderedEntities.length).toBeGreaterThan(0);
 
@@ -181,9 +181,7 @@ describe('Layer Aggregation Integration (ADR-0014)', () => {
       await heatbox.createFromEntities(entities);
 
       const allEntities = Array.from(viewer.entities.values);
-      const renderedEntities = allEntities.filter(e => 
-        e.properties && e.properties.type === 'voxel'
-      );
+      const renderedEntities = allEntities.filter(e => entityType(e) === 'voxel');
 
       const voxelEntity = renderedEntities[0];
       expect(voxelEntity.description).toBeDefined();
@@ -219,9 +217,7 @@ describe('Layer Aggregation Integration (ADR-0014)', () => {
       await heatbox.createFromEntities(entities);
 
       const allEntities = Array.from(viewer.entities.values);
-      const renderedEntities = allEntities.filter(e => 
-        e.properties && e.properties.type === 'voxel'
-      );
+      const renderedEntities = allEntities.filter(e => entityType(e) === 'voxel');
 
       const voxelEntity = renderedEntities[0];
       const description = voxelEntity.description;
@@ -337,9 +333,7 @@ describe('Layer Aggregation Integration (ADR-0014)', () => {
       await heatbox.createFromEntities(entities);
 
       const allEntities = Array.from(viewer.entities.values);
-      const renderedEntities = allEntities.filter(e => 
-        e.properties && e.properties.type === 'voxel'
-      );
+      const renderedEntities = allEntities.filter(e => entityType(e) === 'voxel');
 
       const voxelEntity = renderedEntities[0];
       const description = voxelEntity.description;
@@ -385,4 +379,3 @@ describe('Layer Aggregation Integration (ADR-0014)', () => {
     });
   });
 });
-

--- a/test/integration/spatial-global-qa.test.js
+++ b/test/integration/spatial-global-qa.test.js
@@ -215,13 +215,9 @@ describe('Global Spatial ID QA (ADR-0015)', () => {
       // Attach metrics to Heatbox instance and verify exposure via getStatistics()
       const statsBefore = await heatbox.createFromEntities(entities);
       expect(statsBefore.spatialIdEnabled).toBe(true);
-
-      heatbox._spatialIdEdgeCaseMetrics = metrics;
-
-      const statsAfter = heatbox.getStatistics();
-      expect(statsAfter).toBeDefined();
-      expect(statsAfter.spatialId).toBeDefined();
-      expect(statsAfter.spatialId.edgeCaseMetrics).toEqual(metrics);
+      expect(statsBefore.spatialId).toBeDefined();
+      expect(statsBefore.spatialId.edgeCaseMetrics).not.toBeNull();
+      expect(statsBefore.spatialId.edgeCaseMetrics.datelineNeighborsChecked).toBeGreaterThan(0);
     });
   });
 });

--- a/test/integration/temporal-integration.test.js
+++ b/test/integration/temporal-integration.test.js
@@ -39,12 +39,18 @@ describe('Temporal Integration', () => {
         {
             start: '2025-01-01T00:00:00Z',
             stop: '2025-01-01T01:00:00Z',
-            data: [{ weight: 10 }]
+            data: Array.from({ length: 2 }, () => ({
+                position: { x: 139.7, y: 35.6, z: 10 },
+                weight: 10
+            }))
         },
         {
             start: '2025-01-01T01:00:00Z',
             stop: '2025-01-01T02:00:00Z',
-            data: [{ weight: 100 }]
+            data: Array.from({ length: 4 }, () => ({
+                position: { x: 139.8, y: 35.7, z: 20 },
+                weight: 100
+            }))
         }
     ];
 
@@ -56,19 +62,19 @@ describe('Temporal Integration', () => {
         heatbox = new MockHeatbox();
     });
 
-    test('Global Scope: should calculate and pass global stats', () => {
+    test('Global Scope: should calculate and pass global voxel-count stats', async () => {
         const options = {
             data: mockData,
             classificationScope: 'global'
         };
 
         controller = new TimeController(viewer, heatbox, options);
-        controller.activate();
+        await controller.activate();
 
         // Check if global stats were calculated and stored
         expect(heatbox._globalStats).toBeDefined();
-        expect(heatbox._globalStats.min).toBe(10);
-        expect(heatbox._globalStats.max).toBe(100);
+        expect(heatbox._globalStats.min).toBe(2);
+        expect(heatbox._globalStats.max).toBe(4);
 
         // Check if stats were passed to setData
         expect(heatbox.options._externalStats).toBeDefined();
@@ -91,7 +97,7 @@ describe('Temporal Integration', () => {
         expect(heatbox.options._externalStats).toBeUndefined();
     });
 
-    test('Global Scope uses heatbox valueProperty when computing stats', () => {
+    test('Global Scope classifies voxel counts independently of valueProperty', async () => {
         heatbox.options.valueProperty = 'intensity';
         heatbox.options.classification = {
             enabled: true,
@@ -104,26 +110,34 @@ describe('Temporal Integration', () => {
                 {
                     start: '2025-01-01T00:00:00Z',
                     stop: '2025-01-01T01:00:00Z',
-                    data: [{ weight: 5, intensity: 100 }]
+                    data: Array.from({ length: 2 }, () => ({
+                        position: { x: 139.7, y: 35.6, z: 10 },
+                        weight: 5,
+                        intensity: 100
+                    }))
                 },
                 {
                     start: '2025-01-01T01:00:00Z',
                     stop: '2025-01-01T02:00:00Z',
-                    data: [{ weight: 10, intensity: 300 }]
+                    data: Array.from({ length: 4 }, () => ({
+                        position: { x: 139.8, y: 35.7, z: 20 },
+                        weight: 10,
+                        intensity: 300
+                    }))
                 }
             ],
             classificationScope: 'global'
         };
 
         controller = new TimeController(viewer, heatbox, options);
-        controller.activate();
+        await controller.activate();
 
         expect(heatbox._globalStats).toBeDefined();
-        expect(heatbox._globalStats.min).toBe(100);
-        expect(heatbox._globalStats.max).toBe(300);
-        expect(heatbox._globalStats.minCount).toBe(100);
-        expect(heatbox._globalStats.maxCount).toBe(300);
-        expect(heatbox._globalStats.classification.breaks).toEqual([100, 200, 300]);
+        expect(heatbox._globalStats.min).toBe(2);
+        expect(heatbox._globalStats.max).toBe(4);
+        expect(heatbox._globalStats.minCount).toBe(2);
+        expect(heatbox._globalStats.maxCount).toBe(4);
+        expect(heatbox._globalStats.classification.breaks).toEqual([2, 3, 4]);
         expect(heatbox.options._externalStats).toBe(heatbox._globalStats);
     });
 });

--- a/test/package/cjs-consumer.cts
+++ b/test/package/cjs-consumer.cts
@@ -1,0 +1,4 @@
+import Heatbox = require('cesium-heatbox');
+
+const constructor: typeof Heatbox = Heatbox;
+void constructor;

--- a/test/package/esm-consumer.mts
+++ b/test/package/esm-consumer.mts
@@ -1,0 +1,11 @@
+import Heatbox, { Heatbox as NamedHeatbox, VERSION, getEnvironmentInfo } from 'cesium-heatbox';
+
+const defaultConstructor: typeof Heatbox = Heatbox;
+const namedConstructor: typeof Heatbox = NamedHeatbox;
+const version: string = VERSION;
+const cesiumVersion: string = getEnvironmentInfo().cesiumVersion;
+
+void defaultConstructor;
+void namedConstructor;
+void version;
+void cesiumVersion;

--- a/test/package/tsconfig.json
+++ b/test/package/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": [
+    "./esm-consumer.mts",
+    "./cjs-consumer.cts"
+  ]
+}

--- a/test/setup.js
+++ b/test/setup.js
@@ -12,7 +12,7 @@ global.window = dom.window;
 // これにより、各テストファイルでCesiumのグローバルオブジェクトを拡張できます
 global.Cesium = {};
 
-const { Cartesian3 } = require('cesium');
+const { Cartesian3, Entity } = require('cesium');
 
 // テストユーティリティ
 global.testUtils = {
@@ -29,10 +29,11 @@ global.testUtils = {
       }
     },
     entities: {
-      add: jest.fn(entity => ({
-        ...entity,
-        isDestroyed: () => false
-      })),
+      add: jest.fn(entity => {
+        const result = new Entity(entity);
+        result.isDestroyed = () => false;
+        return result;
+      }),
       remove: jest.fn(),
       removeAll: jest.fn()
     },

--- a/test/utils/validation.test.js
+++ b/test/utils/validation.test.js
@@ -183,6 +183,25 @@ describe('validation.js', () => {
           expect.stringContaining('Invalid colorMap')
         );
       });
+
+      test('highlightStyleを既定値と深くマージして範囲を正規化する', () => {
+        const normalized = validateAndNormalizeOptions({
+          highlightStyle: { boostOutlineWidth: 1.5 }
+        });
+
+        expect(normalized.highlightStyle).toEqual({
+          outlineWidth: 4,
+          boostOpacity: 0.2,
+          boostOutlineWidth: 1.5
+        });
+      });
+
+      test.each([0, -1, NaN, Infinity])(
+        'maxRenderVoxels=%s は既定値へフォールバックする',
+        value => {
+          expect(validateAndNormalizeOptions({ maxRenderVoxels: value }).maxRenderVoxels).toBe(50000);
+        }
+      );
     });
   });
 });

--- a/tools/build-types.js
+++ b/tools/build-types.js
@@ -4,7 +4,11 @@ const fs = require('fs');
 const path = require('path');
 
 const outDir = path.join(__dirname, '..', 'types');
-const outFile = path.join(outDir, 'index.d.ts');
+const outFiles = [
+  path.join(outDir, 'index.d.ts'),
+  path.join(outDir, 'index.d.mts')
+];
+const cjsOutFile = path.join(outDir, 'index.d.cts');
 
 const dts = `
 // Type definitions for cesium-heatbox
@@ -332,5 +336,8 @@ export const REPOSITORY: string;
 `;
 
 fs.mkdirSync(outDir, { recursive: true });
-fs.writeFileSync(outFile, dts, 'utf8');
-console.log(`Types written to ${outFile}`);
+for (const outFile of outFiles) {
+  fs.writeFileSync(outFile, dts, 'utf8');
+}
+fs.writeFileSync(cjsOutFile, `import Heatbox from './index.mjs';\nexport = Heatbox;\n`, 'utf8');
+console.log(`Types written to ${outDir}`);

--- a/tools/package-smoke-test.js
+++ b/tools/package-smoke-test.js
@@ -3,18 +3,27 @@
 const assert = require('assert');
 const path = require('path');
 const { pathToFileURL } = require('url');
+const { execFileSync } = require('child_process');
 
 async function main() {
   const packageRoot = path.join(__dirname, '..');
   const commonJsExport = require(packageRoot);
   assert.strictEqual(typeof commonJsExport, 'function', 'CommonJS export must be the Heatbox constructor');
+  assert.strictEqual(commonJsExport.Heatbox, undefined, 'CommonJS must not advertise unavailable named exports');
 
   const esmPath = path.join(packageRoot, 'dist', 'cesium-heatbox.min.mjs');
   const esmExport = await import(pathToFileURL(esmPath).href);
   assert.strictEqual(typeof esmExport.default, 'function', 'ESM default export must be the Heatbox constructor');
   assert.strictEqual(typeof esmExport.Heatbox, 'function', 'ESM named Heatbox export must exist');
+  assert.strictEqual(typeof esmExport.getEnvironmentInfo, 'function', 'ESM named helpers must exist');
 
-  console.log('Package exports OK (CommonJS + ESM)');
+  execFileSync(process.execPath, [
+    require.resolve('typescript/bin/tsc'),
+    '--project',
+    path.join(packageRoot, 'test', 'package', 'tsconfig.json')
+  ], { cwd: packageRoot, stdio: 'pipe' });
+
+  console.log('Package exports and conditional types OK (CommonJS + ESM)');
 }
 
 main().catch((error) => {


### PR DESCRIPTION
## Summary
- fix Cesium PropertyBag click handling, thick-frame lifecycle, temporal voxel-count statistics, spatial QA metrics, render limits, selection, and fit-view options
- align ESM/CommonJS runtime exports with conditional TypeScript declarations and clean package outputs
- repair example/documentation paths and configure the npm trusted-publishing environment
- bump prerelease version to 1.3.7-alpha.2

## Validation
- npm run -s lint
- npm run -s type-check
- CI=1 npm test --silent -- --runInBand --reporters=summary --bail=1 (40 suites, 508 passed, 1 skipped)
- coverage: statements 81.14%, branches 71.22%, functions 89.76%, lines 82.04%
- npm run build
- npm pack --dry-run --json