### PR TITLE
fix(release): ensure npm trusted publishing support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,13 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
           package-manager-cache: false
+
+      - name: Ensure npm supports trusted publishing
+        run: |
+          npm install --global "npm@^11.15.0"
+          npm --version
       
       - name: Install dependencies
         run: npm ci

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - temporal global classification を実際のボクセル件数ドメインに統一し、Spatial ID QA metrics を統計へ自動反映しました。
 - `maxRenderVoxels`、TopN style、coverage/hybrid 選択、`fitView` オプションの境界処理を修正しました。
 - CommonJS/ESM の条件付き型定義と実行時 export を一致させ、ビルド生成物とサンプルリンクを整理しました。
-- npm Trusted Publishing 用に release job の GitHub Environment を `cesium-heatbox` へ設定しました。
+- npm Trusted Publishing 用に release job の GitHub Environment と registry を設定し、対応 npm CLI バージョンを保証しました。
 
 ## [1.3.6] - 2026-04-13
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cesium-heatbox",
-  "version": "1.3.7-alpha.2",
+  "version": "1.3.7-alpha.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cesium-heatbox",
-      "version": "1.3.7-alpha.2",
+      "version": "1.3.7-alpha.3",
       "license": "MIT",
       "dependencies": {
         "simple-statistics": "^7.8.8"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cesium-heatbox",
-  "version": "1.3.7-alpha.2",
+  "version": "1.3.7-alpha.3",
   "description": "3D voxel-based heatmap visualization library for CesiumJS",
   "main": "dist/cesium-heatbox.cjs",
   "module": "dist/cesium-heatbox.min.mjs",

--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,7 @@ export { Heatbox as CesiumHeatbox };
  * Library metadata.
  * ライブラリのメタ情報。
  */
-export const VERSION = '1.3.7-alpha.2';
+export const VERSION = '1.3.7-alpha.3';
 export const AUTHOR = 'hiro-nyon';
 export const REPOSITORY = 'https://github.com/hiro-nyon/cesium-heatbox';
 


### PR DESCRIPTION
## Summary
- restore the npm registry URL in the release workflow
- upgrade npm to a Trusted Publishing-compatible v11 release
- bump the prerelease version to 1.3.7-alpha.3

## Validation
- npm run -s lint
- npm run -s type-check
- npm run build

## Context
The v1.3.7-alpha.2 release completed validation but npm publish failed with ENEEDAUTH before OIDC exchange.