### PR TITLE
chore(release): prepare v1.3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.7] - 2026-08-11
+
+### Added
+- 公開API、Markdownアンカー、リポジトリ/Wikiリンク、生成Wikiの再現性を検査するドキュメント品質ゲートと、配布物の第三者ライセンス表示を追加しました。
+
+### Changed
+- Ouranos-GEX公式providerを固定commit・integrity・upstream lockfileから再現可能にbuildし、ESM、CJS、UMDの遅延chunkとして同梱する方式へ変更しました。利用者側の追加インストールは不要です。
+- npm公開workflowをタグpush専用にし、版番号・ブランチレーン・未公開版・Release notes本文をfail-closedで検証するよう強化しました。
+
+### Fixed
+- 公開APIと型定義、Spatial IDフォールバック説明、Quick Start、開発/リリース手順、Wikiリンクの不一致を修正しました。
+- GitHub ActionsでOuranosのbuild依存が欠落し、公式providerの遅延chunkを含まないパッケージが生成される問題を修正しました。
+
 ## [1.3.7-alpha.5] - 2026-08-11
 
 ### Fixed

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,4 +1,4 @@
-# API Reference (APIリファレンス) - v1.3.7-alpha.5
+# API Reference (APIリファレンス) - v1.3.7
 
 [English](#english) | [日本語](#日本語)
 

--- a/docs/RELEASE_RUNBOOK.md
+++ b/docs/RELEASE_RUNBOOK.md
@@ -146,9 +146,10 @@ Workflow は npm publish が成功した後に GitHub Release を作成し、安
 ```bash
 npm view cesium-heatbox dist-tags --json
 npm view cesium-heatbox@1.3.7 version gitHead dist.attestations --json
+gh release view v1.3.7 --json tagName,isDraft,isPrerelease,body,url
 ```
 
-`latest=1.3.7`、provenanceあり、`gitHead`がmain/next共通コミットと一致することを確認します。続けて、新規ディレクトリで `npm install cesium-heatbox` を実行し、既定インストールが `1.3.7` になることを確認します。
+`latest=1.3.7`、provenanceあり、`gitHead`がmain/next共通コミットと一致することを確認します。GitHub Releaseは`isDraft=false`、`isPrerelease=false`、`body`が空でなく、`What's Changed`と前版からの`Full Changelog`を含むことを確認します。続けて、公開Wikiの更新と、新規ディレクトリでの`npm install cesium-heatbox`を確認し、既定インストールが`1.3.7`になることを検証します。
 
 ## 7. 失敗時の扱い
 
@@ -178,4 +179,6 @@ Gitタグの削除はnpmパッケージを削除せず、dist-tagも変更しま
 - [ ] alphaタグはnext先端、安定版タグはmain/next共通先端に付いている。
 - [ ] `git push origin <exact-tag>` で1タグだけpushした。
 - [ ] npm dist-tag、gitHead、provenanceを確認した。
+- [ ] GitHub Release notesが非空で、正式版属性と比較リンクが正しい。
+- [ ] 公開Wikiがstableタグの内容へ更新されている。
 - [ ] 安定版では `latest` のインストールとGitHub Release、Wikiを確認した。

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -8,7 +8,7 @@
 **Last Updated**: September 2025  
 **Author**: hiro-nyon  
 
-> Historical design baseline: this specification describes the v0.1.9 architecture and is retained for design context. For the current v1.3.7-alpha.5 public API and behavior, see [API Reference](API.md), [Quick Start](quick-start.md), and the source code.
+> Historical design baseline: this specification describes the v0.1.9 architecture and is retained for design context. For the current v1.3.7 public API and behavior, see [API Reference](API.md), [Quick Start](quick-start.md), and the source code.
 
 ### Table of Contents
 
@@ -277,7 +277,7 @@ For detailed specifications, constraints, and implementation guidelines, see the
 **最終更新**: 2025年9月  
 **作成者**: hiro-nyon  
 
-> 歴史的な設計基準: この仕様書はv0.1.9時点のアーキテクチャを記録したものです。現在のv1.3.7-alpha.5の公開APIと動作は、[APIリファレンス](API.md)、[クイックスタート](quick-start.md)、ソースコードを参照してください。
+> 歴史的な設計基準: この仕様書はv0.1.9時点のアーキテクチャを記録したものです。現在のv1.3.7の公開APIと動作は、[APIリファレンス](API.md)、[クイックスタート](quick-start.md)、ソースコードを参照してください。
 
 ## 目次
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cesium-heatbox",
-  "version": "1.3.7-alpha.5",
+  "version": "1.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cesium-heatbox",
-      "version": "1.3.7-alpha.5",
+      "version": "1.3.7",
       "license": "MIT",
       "dependencies": {
         "simple-statistics": "^7.8.8"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cesium-heatbox",
-  "version": "1.3.7-alpha.5",
+  "version": "1.3.7",
   "description": "3D voxel-based heatmap visualization library for CesiumJS",
   "main": "dist/cesium-heatbox.cjs",
   "module": "dist/cesium-heatbox.min.mjs",

--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,7 @@ export { Heatbox as CesiumHeatbox };
  * Library metadata.
  * ライブラリのメタ情報。
  */
-export const VERSION = '1.3.7-alpha.5';
+export const VERSION = '1.3.7';
 export const AUTHOR = 'hiro-nyon';
 export const REPOSITORY = 'https://github.com/hiro-nyon/cesium-heatbox';
 

--- a/wiki/API-Reference.md
+++ b/wiki/API-Reference.md
@@ -26,7 +26,7 @@ This documentation is auto-generated from JSDoc comments in the source code.
 
 ### Version Information
 
-- **Current Version**: 1.3.7-alpha.5
+- **Current Version**: 1.3.7
 - **Last Updated**: 2026-08-11
 - **Generated From**: JSDoc → Markdown conversion
 
@@ -60,7 +60,7 @@ This documentation is auto-generated from JSDoc comments in the source code.
 
 ### バージョン情報
 
-- **現在のバージョン**: 1.3.7-alpha.5
+- **現在のバージョン**: 1.3.7
 - **最終更新**: 2026-08-11
 - **生成元**: JSDoc → Markdown変換
 

--- a/wiki/API.md
+++ b/wiki/API.md
@@ -1,6 +1,6 @@
 <!-- Generated from docs/API.md by npm run wiki:sync. Edit the canonical source, not this page. -->
 
-# API Reference (APIリファレンス) - v1.3.7-alpha.5
+# API Reference (APIリファレンス) - v1.3.7
 
 [English](#english) | [日本語](#日本語)
 

--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -10,7 +10,7 @@
 **Last Updated**: September 2025
 **Author**: hiro-nyon
 
-> Historical design baseline: this specification describes the v0.1.9 architecture and is retained for design context. For the current v1.3.7-alpha.5 public API and behavior, see [API Reference](API), [Quick Start](Quick-Start), and the source code.
+> Historical design baseline: this specification describes the v0.1.9 architecture and is retained for design context. For the current v1.3.7 public API and behavior, see [API Reference](API), [Quick Start](Quick-Start), and the source code.
 
 ### Table of Contents
 
@@ -279,7 +279,7 @@ For detailed specifications, constraints, and implementation guidelines, see the
 **最終更新**: 2025年9月
 **作成者**: hiro-nyon
 
-> 歴史的な設計基準: この仕様書はv0.1.9時点のアーキテクチャを記録したものです。現在のv1.3.7-alpha.5の公開APIと動作は、[APIリファレンス](API)、[クイックスタート](Quick-Start)、ソースコードを参照してください。
+> 歴史的な設計基準: この仕様書はv0.1.9時点のアーキテクチャを記録したものです。現在のv1.3.7の公開APIと動作は、[APIリファレンス](API)、[クイックスタート](Quick-Start)、ソースコードを参照してください。
 
 ## 目次
 

--- a/wiki/Release-Notes.md
+++ b/wiki/Release-Notes.md
@@ -43,6 +43,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.7] - 2026-08-11
+
+### Added
+- 公開API、Markdownアンカー、リポジトリ/Wikiリンク、生成Wikiの再現性を検査するドキュメント品質ゲートと、配布物の第三者ライセンス表示を追加しました。
+
+### Changed
+- Ouranos-GEX公式providerを固定commit・integrity・upstream lockfileから再現可能にbuildし、ESM、CJS、UMDの遅延chunkとして同梱する方式へ変更しました。利用者側の追加インストールは不要です。
+- npm公開workflowをタグpush専用にし、版番号・ブランチレーン・未公開版・Release notes本文をfail-closedで検証するよう強化しました。
+
+### Fixed
+- 公開APIと型定義、Spatial IDフォールバック説明、Quick Start、開発/リリース手順、Wikiリンクの不一致を修正しました。
+- GitHub ActionsでOuranosのbuild依存が欠落し、公式providerの遅延chunkを含まないパッケージが生成される問題を修正しました。
+
 ## [1.3.7-alpha.5] - 2026-08-11
 
 ### Fixed

--- a/wiki/Release-Runbook.md
+++ b/wiki/Release-Runbook.md
@@ -148,9 +148,10 @@ Workflow は npm publish が成功した後に GitHub Release を作成し、安
 ```bash
 npm view cesium-heatbox dist-tags --json
 npm view cesium-heatbox@1.3.7 version gitHead dist.attestations --json
+gh release view v1.3.7 --json tagName,isDraft,isPrerelease,body,url
 ```
 
-`latest=1.3.7`、provenanceあり、`gitHead`がmain/next共通コミットと一致することを確認します。続けて、新規ディレクトリで `npm install cesium-heatbox` を実行し、既定インストールが `1.3.7` になることを確認します。
+`latest=1.3.7`、provenanceあり、`gitHead`がmain/next共通コミットと一致することを確認します。GitHub Releaseは`isDraft=false`、`isPrerelease=false`、`body`が空でなく、`What's Changed`と前版からの`Full Changelog`を含むことを確認します。続けて、公開Wikiの更新と、新規ディレクトリでの`npm install cesium-heatbox`を確認し、既定インストールが`1.3.7`になることを検証します。
 
 ## 7. 失敗時の扱い
 
@@ -180,4 +181,6 @@ Gitタグの削除はnpmパッケージを削除せず、dist-tagも変更しま
 - [ ] alphaタグはnext先端、安定版タグはmain/next共通先端に付いている。
 - [ ] `git push origin <exact-tag>` で1タグだけpushした。
 - [ ] npm dist-tag、gitHead、provenanceを確認した。
+- [ ] GitHub Release notesが非空で、正式版属性と比較リンクが正しい。
+- [ ] 公開Wikiがstableタグの内容へ更新されている。
 - [ ] 安定版では `latest` のインストールとGitHub Release、Wikiを確認した。

--- a/wiki/index.js.md
+++ b/wiki/index.js.md
@@ -32,7 +32,7 @@ export { Heatbox as CesiumHeatbox };
  * Library metadata.
  * ライブラリのメタ情報。
  */
-export const VERSION = '1.3.7-alpha.5';
+export const VERSION = '1.3.7';
 export const AUTHOR = 'hiro-nyon';
 export const REPOSITORY = 'https://github.com/hiro-nyon/cesium-heatbox';
 
@@ -104,7 +104,7 @@ export { Heatbox as CesiumHeatbox };
  * Library metadata.
  * ライブラリのメタ情報。
  */
-export const VERSION = '1.3.7-alpha.5';
+export const VERSION = '1.3.7';
 export const AUTHOR = 'hiro-nyon';
 export const REPOSITORY = 'https://github.com/hiro-nyon/cesium-heatbox';
 


### PR DESCRIPTION
## Summary
- promote the audited 1.3.7-alpha.5 package to stable 1.3.7
- finalize the stable CHANGELOG entry and generated Wiki release notes
- add explicit post-release checks for non-empty GitHub Release notes and stable attributes

## Verification
- npm run lint
- npm run type-check
- npm test (41 suites, 513 passed, 1 skipped)
- npm run test:docs
- npm run build
- npm pack --dry-run (21 files)
- npm audit --omit=dev (0 vulnerabilities)
- independent docs, package, and release audits
- published alpha.5 registry audit across ESM, CJS, and browser UMD