### PR TITLE
fix(docs): sync Wiki deletions after v1.3.7

### DIFF
--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -11,9 +11,11 @@ on:
       - 'docs/**'
       - 'wiki/**'
       - 'tools/wiki-sync.js'
+      - 'tools/wiki/publish-wiki.sh'
       - 'jsdoc.config.json'
       - 'package.json'
       - 'README.md'
+      - 'README.ja.md'
       - 'CHANGELOG.md'
   workflow_dispatch:
     inputs:
@@ -55,56 +57,10 @@ jobs:
       run: |
         npm run wiki:sync
     
-    - name: Configure Git
-      if: ${{ success() }}
-      run: |
-        git config --global user.name "github-actions[bot]"
-        git config --global user.email "github-actions[bot]@users.noreply.github.com"
-
-    - name: Clone Wiki repository
+    - name: Publish Wiki mirror
       env:
         WIKI_TOKEN: ${{ secrets.WIKI_TOKEN != '' && secrets.WIKI_TOKEN || secrets.GITHUB_TOKEN }}
-      run: |
-        git clone https://x-access-token:${WIKI_TOKEN}@github.com/hiro-nyon/cesium-heatbox.wiki.git .wiki-tmp
-
-    - name: Update Wiki content
-      if: ${{ success() }}
-      run: |
-        # 安全確認：重要ページのバックアップ
-        if [ -f ".wiki-tmp/Home.md" ]; then
-          cp .wiki-tmp/Home.md .wiki-tmp/Home.md.backup
-        fi
-        
-        # コンテンツ同期
-        cp -f wiki/*.md .wiki-tmp/
-        
-        cd .wiki-tmp
-        
-        # 変更確認
-        if git diff --quiet; then
-          echo "No changes to commit to wiki"
-          exit 0
-        fi
-        
-        # 変更内容表示（セキュリティ確認）
-        echo "Wiki changes to be committed:"
-        git diff --name-only
-        git diff --stat
-        
-        # コミット・プッシュ
-        git add .
-        git commit -m "docs: auto-sync from main branch ($(date -u '+%Y-%m-%d %H:%M:%S UTC'))
-
-        Source commit: ${{ github.sha }}
-        Triggered by: ${{ github.event_name }}
-        Actor: ${{ github.actor }}"
-        
-        git push origin master
-    
-    - name: Cleanup
-      if: ${{ always() }}
-      run: |
-        rm -rf .wiki-tmp
+      run: bash tools/wiki/publish-wiki.sh hiro-nyon cesium-heatbox
         
     - name: Notify success
       if: ${{ success() }}

--- a/docs/wiki-maintenance.md
+++ b/docs/wiki-maintenance.md
@@ -6,7 +6,7 @@
 
 ### Overview
 
-GitHub Wiki synchronization is driven by `npm run wiki:sync`. The sync process regenerates API reference pages from JSDoc and mirrors the main Markdown entry pages used by the Wiki.
+GitHub Wiki synchronization is driven by `npm run wiki:sync`. The sync process regenerates API reference pages from JSDoc and mirrors the main Markdown entry pages used by the Wiki. Publishing treats the tracked `wiki/*.md` set as authoritative, so pages removed from the repository are also removed from the public Wiki while remaining recoverable from Wiki Git history.
 
 ### Automation Configuration
 
@@ -175,7 +175,7 @@ npm run wiki:update
 
 ## 概要
 
-GitHub Wiki の同期は `npm run wiki:sync` を中心に行います。JSDoc から生成した API リファレンスに加え、Wiki の主要エントリページとして使う Markdown も同じ処理で `wiki/` に反映されます。
+GitHub Wiki の同期は `npm run wiki:sync` を中心に行います。JSDoc から生成した API リファレンスに加え、Wiki の主要エントリページとして使う Markdown も同じ処理で `wiki/` に反映されます。公開時は追跡中の`wiki/*.md`を正本としてミラーし、リポジトリから削除されたページは公開Wikiからも削除します。削除内容はWikiのGit履歴から復元できます。
 
 ## 自動化の構成
 

--- a/tools/wiki/publish-wiki.sh
+++ b/tools/wiki/publish-wiki.sh
@@ -14,13 +14,15 @@ if [[ -z "$OWNER" || -z "$REPO" ]]; then
 fi
 
 WIKI_URL="https://github.com/${OWNER}/${REPO}.wiki.git"
-WORKDIR=".wiki-tmp"
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
 
 echo "Cloning: ${WIKI_URL} ..."
-rm -rf "$WORKDIR"
 git clone "$WIKI_URL" "$WORKDIR"
+git -C "$WORKDIR" checkout "$BRANCH"
 
-echo "Copying wiki/*.md -> ${WORKDIR}/ ..."
+echo "Mirroring wiki/*.md -> ${WORKDIR}/ ..."
+find "$WORKDIR" -maxdepth 1 -type f -name '*.md' -delete
 cp -f wiki/*.md "$WORKDIR"/
 
 pushd "$WORKDIR" >/dev/null
@@ -43,7 +45,6 @@ else
   echo "Warning: No WIKI_TOKEN/GH_TOKEN/GITHUB_TOKEN provided; push may fail due to auth" >&2
 fi
 
-git checkout "$BRANCH" || true
 git add .
 if git diff --cached --quiet; then
   echo "No changes to commit."

--- a/wiki/Publishing-to-GitHub-Wiki.md
+++ b/wiki/Publishing-to-GitHub-Wiki.md
@@ -8,7 +8,7 @@
 
 ### Overview
 
-GitHub Wiki synchronization is driven by `npm run wiki:sync`. The sync process regenerates API reference pages from JSDoc and mirrors the main Markdown entry pages used by the Wiki.
+GitHub Wiki synchronization is driven by `npm run wiki:sync`. The sync process regenerates API reference pages from JSDoc and mirrors the main Markdown entry pages used by the Wiki. Publishing treats the tracked `wiki/*.md` set as authoritative, so pages removed from the repository are also removed from the public Wiki while remaining recoverable from Wiki Git history.
 
 ### Automation Configuration
 
@@ -177,7 +177,7 @@ npm run wiki:update
 
 ## 概要
 
-GitHub Wiki の同期は `npm run wiki:sync` を中心に行います。JSDoc から生成した API リファレンスに加え、Wiki の主要エントリページとして使う Markdown も同じ処理で `wiki/` に反映されます。
+GitHub Wiki の同期は `npm run wiki:sync` を中心に行います。JSDoc から生成した API リファレンスに加え、Wiki の主要エントリページとして使う Markdown も同じ処理で `wiki/` に反映されます。公開時は追跡中の`wiki/*.md`を正本としてミラーし、リポジトリから削除されたページは公開Wikiからも削除します。削除内容はWikiのGit履歴から復元できます。
 
 ## 自動化の構成
 


### PR DESCRIPTION
## Summary
- promote the reviewed Wiki mirror hotfix to main
- remove obsolete public Wiki pages that are absent from tracked wiki sources
- keep deleted pages recoverable through Wiki Git history

This is post-release documentation maintenance only. It does not publish or modify the npm package.